### PR TITLE
feat: adiciona rotas de API para labirintos e corridas

### DIFF
--- a/src/backend/config/urls.py
+++ b/src/backend/config/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('telemetria.urls')),
 ]

--- a/src/backend/telemetria/tests.py
+++ b/src/backend/telemetria/tests.py
@@ -2,7 +2,7 @@ import json
 
 from django.test import TestCase
 
-from .models import Labirinto
+from .models import Corrida, Labirinto
 
 
 class LabirintosApiTests(TestCase):
@@ -78,3 +78,67 @@ class LabirintosApiTests(TestCase):
         response = self.client.get(f"/api/labirintos/{labirinto.id}/")
 
         self.assertEqual(response.status_code, 200)
+
+
+class CorridasApiTests(TestCase):
+    endpoint = "/api/corridas"
+
+    def test_cria_corrida(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto corrida", tamanho=16)
+
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"labirinto_id": labirinto.id}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["labirinto_id"], labirinto.id)
+        self.assertFalse(response.json()["desafio_concluido"])
+        self.assertIn("iniciado_em", response.json())
+        self.assertEqual(Corrida.objects.count(), 1)
+
+    def test_retorna_404_quando_labirinto_nao_existe(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"labirinto_id": 999}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["erro"], "Labirinto nao encontrado.")
+        self.assertEqual(Corrida.objects.count(), 0)
+
+    def test_rejeita_labirinto_id_invalido(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"labirinto_id": "1"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["erro"],
+            "O campo labirinto_id e obrigatorio e deve ser inteiro.",
+        )
+
+    def test_rejeita_json_invalido(self):
+        response = self.client.post(
+            self.endpoint,
+            data="{",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["erro"], "JSON invalido.")
+
+    def test_aceita_rota_com_barra_final(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto barra", tamanho=4)
+
+        response = self.client.post(
+            "/api/corridas/",
+            data=json.dumps({"labirinto_id": labirinto.id}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)

--- a/src/backend/telemetria/tests.py
+++ b/src/backend/telemetria/tests.py
@@ -55,3 +55,26 @@ class LabirintosApiTests(TestCase):
         response = self.client.get("/api/labirintos/")
 
         self.assertEqual(response.status_code, 200)
+
+    def test_busca_labirinto_por_id(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto 03", tamanho=4)
+
+        response = self.client.get(f"/api/labirintos/{labirinto.id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], labirinto.id)
+        self.assertEqual(response.json()["nome"], "Labirinto 03")
+        self.assertEqual(response.json()["tamanho"], 4)
+
+    def test_retorna_404_para_labirinto_inexistente(self):
+        response = self.client.get("/api/labirintos/999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["erro"], "Labirinto nao encontrado.")
+
+    def test_busca_por_id_aceita_barra_final(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto 04", tamanho=8)
+
+        response = self.client.get(f"/api/labirintos/{labirinto.id}/")
+
+        self.assertEqual(response.status_code, 200)

--- a/src/backend/telemetria/tests.py
+++ b/src/backend/telemetria/tests.py
@@ -1,3 +1,57 @@
+import json
+
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Labirinto
+
+
+class LabirintosApiTests(TestCase):
+    endpoint = "/api/labirintos"
+
+    def test_lista_labirintos(self):
+        Labirinto.objects.create(nome="Labirinto 01", tamanho=16)
+
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]["nome"], "Labirinto 01")
+        self.assertIn("created_at", response.json()[0])
+
+    def test_cria_labirinto(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"nome": "Labirinto 02", "tamanho": 8}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["nome"], "Labirinto 02")
+        self.assertEqual(response.json()["tamanho"], 8)
+        self.assertEqual(Labirinto.objects.count(), 1)
+
+    def test_rejeita_tamanho_fora_do_padrao(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"nome": "Labirinto invalido", "tamanho": 10}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["erro"], "O campo tamanho deve ser 4, 8 ou 16.")
+        self.assertEqual(Labirinto.objects.count(), 0)
+
+    def test_rejeita_json_invalido(self):
+        response = self.client.post(
+            self.endpoint,
+            data="{",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["erro"], "JSON invalido.")
+
+    def test_aceita_rota_com_barra_final(self):
+        response = self.client.get("/api/labirintos/")
+
+        self.assertEqual(response.status_code, 200)

--- a/src/backend/telemetria/tests.py
+++ b/src/backend/telemetria/tests.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 
 from django.test import TestCase
 
@@ -142,3 +143,53 @@ class CorridasApiTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 201)
+
+    def test_busca_corrida_por_id(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto detalhe", tamanho=8)
+        finalizado_em = datetime(2026, 5, 26, 18, 30, tzinfo=timezone.utc)
+        corrida = Corrida.objects.create(
+            labitinto_id=labirinto,
+            tempo_conclusao_sec=42.7,
+            velocidade_med=16.9,
+            consumo_bat=0.8,
+            desafio_concluido=True,
+            finalizado_em=finalizado_em,
+        )
+
+        response = self.client.get(f"/api/corridas/{corrida.id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], corrida.id)
+        self.assertEqual(response.json()["labirinto_id"], labirinto.id)
+        self.assertEqual(response.json()["tempo_conclusao_sec"], 42.7)
+        self.assertEqual(response.json()["velocidade_media"], 16.9)
+        self.assertEqual(response.json()["consumo_bateria"], 0.8)
+        self.assertTrue(response.json()["desafio_concluido"])
+        self.assertIn("iniciado_em", response.json())
+        self.assertEqual(response.json()["finalizado_em"], "2026-05-26T18:30:00+00:00")
+
+    def test_detalhe_de_corrida_em_andamento_retorna_campos_nulos(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto em andamento", tamanho=16)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+
+        response = self.client.get(f"/api/corridas/{corrida.id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["tempo_conclusao_sec"])
+        self.assertIsNone(response.json()["velocidade_media"])
+        self.assertIsNone(response.json()["consumo_bateria"])
+        self.assertIsNone(response.json()["finalizado_em"])
+
+    def test_retorna_404_para_corrida_inexistente(self):
+        response = self.client.get("/api/corridas/999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["erro"], "Corrida nao encontrada.")
+
+    def test_busca_corrida_por_id_aceita_barra_final(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto detalhe barra", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+
+        response = self.client.get(f"/api/corridas/{corrida.id}/")
+
+        self.assertEqual(response.status_code, 200)

--- a/src/backend/telemetria/tests/test_corrida.py
+++ b/src/backend/telemetria/tests/test_corrida.py
@@ -1,85 +1,7 @@
-import json
-from datetime import datetime, timezone
-
 from django.test import TestCase
-
-from .models import Corrida, Labirinto
-
-
-class LabirintosApiTests(TestCase):
-    endpoint = "/api/labirintos"
-
-    def test_lista_labirintos(self):
-        Labirinto.objects.create(nome="Labirinto 01", tamanho=16)
-
-        response = self.client.get(self.endpoint)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()), 1)
-        self.assertEqual(response.json()[0]["nome"], "Labirinto 01")
-        self.assertIn("created_at", response.json()[0])
-
-    def test_cria_labirinto(self):
-        response = self.client.post(
-            self.endpoint,
-            data=json.dumps({"nome": "Labirinto 02", "tamanho": 8}),
-            content_type="application/json",
-        )
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.json()["nome"], "Labirinto 02")
-        self.assertEqual(response.json()["tamanho"], 8)
-        self.assertEqual(Labirinto.objects.count(), 1)
-
-    def test_rejeita_tamanho_fora_do_padrao(self):
-        response = self.client.post(
-            self.endpoint,
-            data=json.dumps({"nome": "Labirinto invalido", "tamanho": 10}),
-            content_type="application/json",
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["erro"], "O campo tamanho deve ser 4, 8 ou 16.")
-        self.assertEqual(Labirinto.objects.count(), 0)
-
-    def test_rejeita_json_invalido(self):
-        response = self.client.post(
-            self.endpoint,
-            data="{",
-            content_type="application/json",
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()["erro"], "JSON invalido.")
-
-    def test_aceita_rota_com_barra_final(self):
-        response = self.client.get("/api/labirintos/")
-
-        self.assertEqual(response.status_code, 200)
-
-    def test_busca_labirinto_por_id(self):
-        labirinto = Labirinto.objects.create(nome="Labirinto 03", tamanho=4)
-
-        response = self.client.get(f"/api/labirintos/{labirinto.id}")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["id"], labirinto.id)
-        self.assertEqual(response.json()["nome"], "Labirinto 03")
-        self.assertEqual(response.json()["tamanho"], 4)
-
-    def test_retorna_404_para_labirinto_inexistente(self):
-        response = self.client.get("/api/labirintos/999")
-
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json()["erro"], "Labirinto nao encontrado.")
-
-    def test_busca_por_id_aceita_barra_final(self):
-        labirinto = Labirinto.objects.create(nome="Labirinto 04", tamanho=8)
-
-        response = self.client.get(f"/api/labirintos/{labirinto.id}/")
-
-        self.assertEqual(response.status_code, 200)
-
+from datetime import datetime, timezone
+import json
+from telemetria.models import Labirinto, Corrida
 
 class CorridasApiTests(TestCase):
     endpoint = "/api/corridas"
@@ -193,3 +115,109 @@ class CorridasApiTests(TestCase):
         response = self.client.get(f"/api/corridas/{corrida.id}/")
 
         self.assertEqual(response.status_code, 200)
+
+    def test_cria_telemetria(self):
+        labirinto=Labirinto.objects.create(nome="Labirinto telemetria", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+        response = self.client.post(f"/api/corridas/{corrida.id}/telemetria/",
+            data=json.dumps({
+                "linha": 0,
+                "coluna": 0,
+                "parede_norte": "livre",
+                "parede_sul": "desconhecido",
+                "parede_leste": "livre",
+                "parede_oeste": "parede",
+                "posicao_ordem": 1,
+                "x": 0.5,
+                "y": 0.5,
+                "direcao": "norte",
+                "velocidade": 1.0,
+                "bateria": 0.5,
+            }),content_type="application/json",
+        )
+        print(response.json())
+        self.assertEqual(response.status_code, 201)
+        self.assertIn("id", response.json())
+
+    def test_corrida_inexistente_404(self):
+        response = self.client.post(f"/api/corridas/999/telemetria/",
+            data=json.dumps({
+                "linha": 0,
+                "coluna": 0,
+                "parede_norte": "livre",
+                "parede_sul": "desconhecido",
+                "parede_leste": "livre",
+                "parede_oeste": "parede",
+                "posicao_ordem": 1,
+                "x": 0.5,
+                "y": 0.5,
+                "direcao": "norte",
+                "velocidade": 1.0,
+                "bateria": 0.5,
+            }),content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.json()["erro"], "Corrida nao encontrada."
+        )
+
+    def test_telemetria_invalida_400(self):
+        labirinto=Labirinto.objects.create(nome="Labirinto telemetria", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+        response = self.client.post(f"/api/corridas/{corrida.id}/telemetria/",
+            data="{",content_type="application/json",
+        )
+        # print(response)
+        self.assertEqual(response.status_code, 400)
+
+    def test_estado_atual_sem_telemetria(self):
+        labirinto=Labirinto.objects.create(nome="Labirinto telemetria", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+        response = self.client.get(f"/api/corridas/{corrida.id}/estado-atual/")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.json()["erro"], "Nenhuma telemetria encontrada."
+        )
+
+    def test_estado_atual_com_telemetria(self):
+        labirinto=Labirinto.objects.create(nome="Labirinto telemetria", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labirinto)
+        response1 = self.client.post(f"/api/corridas/{corrida.id}/telemetria/",
+            data=json.dumps({
+                "linha": 0,
+                "coluna": 0,
+                "parede_norte": "livre",
+                "parede_sul": "desconhecido",
+                "parede_leste": "livre",
+                "parede_oeste": "parede",
+                "posicao_ordem": 1,
+                "x": 0.5,
+                "y": 0.5,
+                "direcao": "norte",
+                "velocidade": 1.0,
+                "bateria": 0.5,
+            }),content_type="application/json",
+        )
+        response2 = self.client.get(f"/api/corridas/{corrida.id}/estado-atual/")
+        self.assertEqual(response2.status_code, 200)
+
+    def test_finalizar_corrida(self):
+        labiritinto=Labirinto.objects.create(nome="Labirinto finalizar", tamanho=4)
+        corrida = Corrida.objects.create(labitinto_id=labiritinto)
+        response = self.client.patch(f"/api/corridas/{corrida.id}/finalizar/",
+            data=json.dumps({
+                "tempo_conclusao_sec": 123.4,
+                "velocidade_med": 10.5,
+                "consumo_bat": 0.7,
+                "desafio_concluido": True,
+
+            }),content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["desafio_concluido"])
+
+    def test_finalizar_corrida_inexistente(self):
+        response = self.client.patch("/api/corridas/999/finalizar/",
+            data=json.dumps({}),
+            content_type="application/json")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["erro"], "Corrida nao encontrada.")

--- a/src/backend/telemetria/tests/test_labirinto.py
+++ b/src/backend/telemetria/tests/test_labirinto.py
@@ -1,0 +1,84 @@
+import json
+from datetime import datetime, timezone
+
+from django.test import TestCase
+
+from telemetria.models import Labirinto
+
+
+class LabirintosApiTests(TestCase):
+    endpoint = "/api/labirintos"
+
+    def test_lista_labirintos(self):
+        Labirinto.objects.create(nome="Labirinto 01", tamanho=16)
+
+        response = self.client.get(self.endpoint)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(response.json()[0]["nome"], "Labirinto 01")
+        self.assertIn("created_at", response.json()[0])
+
+    def test_cria_labirinto(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"nome": "Labirinto 02", "tamanho": 8}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json()["nome"], "Labirinto 02")
+        self.assertEqual(response.json()["tamanho"], 8)
+        self.assertEqual(Labirinto.objects.count(), 1)
+
+    def test_rejeita_tamanho_fora_do_padrao(self):
+        response = self.client.post(
+            self.endpoint,
+            data=json.dumps({"nome": "Labirinto invalido", "tamanho": 10}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["erro"], "O campo tamanho deve ser 4, 8 ou 16.")
+        self.assertEqual(Labirinto.objects.count(), 0)
+
+    def test_rejeita_json_invalido(self):
+        response = self.client.post(
+            self.endpoint,
+            data="{",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["erro"], "JSON invalido.")
+
+    def test_aceita_rota_com_barra_final(self):
+        response = self.client.get("/api/labirintos/")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_busca_labirinto_por_id(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto 03", tamanho=4)
+
+        response = self.client.get(f"/api/labirintos/{labirinto.id}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["id"], labirinto.id)
+        self.assertEqual(response.json()["nome"], "Labirinto 03")
+        self.assertEqual(response.json()["tamanho"], 4)
+
+    def test_retorna_404_para_labirinto_inexistente(self):
+        response = self.client.get("/api/labirintos/999")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["erro"], "Labirinto nao encontrado.")
+
+    def test_busca_por_id_aceita_barra_final(self):
+        labirinto = Labirinto.objects.create(nome="Labirinto 04", tamanho=8)
+
+        response = self.client.get(f"/api/labirintos/{labirinto.id}/")
+
+        self.assertEqual(response.status_code, 200)
+
+
+

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -6,4 +6,14 @@ from . import views
 urlpatterns = [
     path("labirintos", views.labirintos, name="labirintos"),
     path("labirintos/", views.labirintos, name="labirintos"),
+    path(
+        "labirintos/<int:labirinto_id>",
+        views.labirinto_detalhe,
+        name="labirinto_detalhe",
+    ),
+    path(
+        "labirintos/<int:labirinto_id>/",
+        views.labirinto_detalhe,
+        name="labirinto_detalhe",
+    ),
 ]

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -18,4 +18,14 @@ urlpatterns = [
     ),
     path("corridas", views.corridas, name="corridas"),
     path("corridas/", views.corridas, name="corridas"),
+    path(
+        "corridas/<int:corrida_id>",
+        views.corrida_detalhe,
+        name="corrida_detalhe",
+    ),
+    path(
+        "corridas/<int:corrida_id>/",
+        views.corrida_detalhe,
+        name="corrida_detalhe",
+    ),
 ]

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from . import views
 
-
 urlpatterns = [
     path("labirintos", views.labirintos, name="labirintos"),
     path("labirintos/", views.labirintos, name="labirintos"),
@@ -41,10 +40,10 @@ urlpatterns = [
         views.estado_atual,
         name="estado_atual",
     ),
-    path("corridas/<int:corrida_id>/finalizar", views.finalizar_corrida, name="finalizar_corrida"),
+    path("corridas/<int:corrida_id>/finalizar", views.finalizar, name="finalizar_corrida"),
     path(
         "corridas/<int:corrida_id>/finalizar/",
-        views.finalizar_corrida,
+        views.finalizar,
         name="finalizar_corrida",
     ),
 

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -28,4 +28,25 @@ urlpatterns = [
         views.corrida_detalhe,
         name="corrida_detalhe",
     ),
+
+    path("corridas/<int:corrida_id>/telemetria", views.telemetria, name="telemetria"),
+    path(
+        "corridas/<int:corrida_id>/telemetria/",
+        views.telemetria,
+        name="telemetria",
+    ),
+    path("corridas/<int:corrida_id>/estado-atual", views.estado_atual, name="estado_atual"),
+    path(
+        "corridas/<int:corrida_id>/estado-atual/",
+        views.estado_atual,
+        name="estado_atual",
+    ),
+    path("corridas/<int:corrida_id>/finalizar", views.finalizar_corrida, name="finalizar_corrida"),
+    path(
+        "corridas/<int:corrida_id>/finalizar/",
+        views.finalizar_corrida,
+        name="finalizar_corrida",
+    ),
+
+
 ]

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -16,4 +16,6 @@ urlpatterns = [
         views.labirinto_detalhe,
         name="labirinto_detalhe",
     ),
+    path("corridas", views.corridas, name="corridas"),
+    path("corridas/", views.corridas, name="corridas"),
 ]

--- a/src/backend/telemetria/urls.py
+++ b/src/backend/telemetria/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    path("labirintos", views.labirintos, name="labirintos"),
+    path("labirintos/", views.labirintos, name="labirintos"),
+]

--- a/src/backend/telemetria/views.py
+++ b/src/backend/telemetria/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/src/backend/telemetria/views/__init__.py
+++ b/src/backend/telemetria/views/__init__.py
@@ -1,4 +1,5 @@
+from .corridas import corridas
 from .labirintos import labirinto_detalhe, labirintos
 
 
-__all__ = ["labirinto_detalhe", "labirintos"]
+__all__ = ["corridas", "labirinto_detalhe", "labirintos"]

--- a/src/backend/telemetria/views/__init__.py
+++ b/src/backend/telemetria/views/__init__.py
@@ -1,0 +1,4 @@
+from .labirintos import labirintos
+
+
+__all__ = ["labirintos"]

--- a/src/backend/telemetria/views/__init__.py
+++ b/src/backend/telemetria/views/__init__.py
@@ -1,5 +1,5 @@
 from .corridas import corrida_detalhe, corridas
-from .labirintos import labirinto_detalhe, labirintos
+from .labirintos import labirinto_detalhe, labirintos,finalizar,estado_atual,telemetria
 
 
-__all__ = ["corrida_detalhe", "corridas", "labirinto_detalhe", "labirintos"]
+__all__ = ["corrida_detalhe", "corridas", "labirinto_detalhe", "labirintos","finalizar","estado_atual","telemetria"]

--- a/src/backend/telemetria/views/__init__.py
+++ b/src/backend/telemetria/views/__init__.py
@@ -1,5 +1,5 @@
-from .corridas import corridas
+from .corridas import corrida_detalhe, corridas
 from .labirintos import labirinto_detalhe, labirintos
 
 
-__all__ = ["corridas", "labirinto_detalhe", "labirintos"]
+__all__ = ["corrida_detalhe", "corridas", "labirinto_detalhe", "labirintos"]

--- a/src/backend/telemetria/views/__init__.py
+++ b/src/backend/telemetria/views/__init__.py
@@ -1,4 +1,4 @@
-from .labirintos import labirintos
+from .labirintos import labirinto_detalhe, labirintos
 
 
-__all__ = ["labirintos"]
+__all__ = ["labirinto_detalhe", "labirintos"]

--- a/src/backend/telemetria/views/corridas.py
+++ b/src/backend/telemetria/views/corridas.py
@@ -1,0 +1,43 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from ..models import Corrida, Labirinto
+
+
+def _serializar_corrida(corrida):
+    return {
+        "id": corrida.id,
+        "labirinto_id": corrida.labitinto_id_id,
+        "desafio_concluido": corrida.desafio_concluido,
+        "iniciado_em": corrida.iniciado_em.isoformat(),
+    }
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def corridas(request):
+    try:
+        dados = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"erro": "JSON invalido."}, status=400)
+
+    if not isinstance(dados, dict):
+        return JsonResponse({"erro": "O corpo deve ser um objeto JSON."}, status=400)
+
+    labirinto_id = dados.get("labirinto_id")
+    if type(labirinto_id) is not int:
+        return JsonResponse(
+            {"erro": "O campo labirinto_id e obrigatorio e deve ser inteiro."},
+            status=400,
+        )
+
+    try:
+        labirinto = Labirinto.objects.get(id=labirinto_id)
+    except Labirinto.DoesNotExist:
+        return JsonResponse({"erro": "Labirinto nao encontrado."}, status=404)
+
+    corrida = Corrida.objects.create(labitinto_id=labirinto)
+    return JsonResponse(_serializar_corrida(corrida), status=201)

--- a/src/backend/telemetria/views/corridas.py
+++ b/src/backend/telemetria/views/corridas.py
@@ -16,6 +16,21 @@ def _serializar_corrida(corrida):
     }
 
 
+def _serializar_corrida_detalhe(corrida):
+    return {
+        "id": corrida.id,
+        "labirinto_id": corrida.labitinto_id_id,
+        "tempo_conclusao_sec": corrida.tempo_conclusao_sec,
+        "velocidade_media": corrida.velocidade_med,
+        "consumo_bateria": corrida.consumo_bat,
+        "desafio_concluido": corrida.desafio_concluido,
+        "iniciado_em": corrida.iniciado_em.isoformat(),
+        "finalizado_em": (
+            corrida.finalizado_em.isoformat() if corrida.finalizado_em else None
+        ),
+    }
+
+
 @csrf_exempt
 @require_http_methods(["POST"])
 def corridas(request):
@@ -41,3 +56,13 @@ def corridas(request):
 
     corrida = Corrida.objects.create(labitinto_id=labirinto)
     return JsonResponse(_serializar_corrida(corrida), status=201)
+
+
+@require_http_methods(["GET"])
+def corrida_detalhe(request, corrida_id):
+    try:
+        corrida = Corrida.objects.get(id=corrida_id)
+    except Corrida.DoesNotExist:
+        return JsonResponse({"erro": "Corrida nao encontrada."}, status=404)
+
+    return JsonResponse(_serializar_corrida_detalhe(corrida))

--- a/src/backend/telemetria/views/labirintos.py
+++ b/src/backend/telemetria/views/labirintos.py
@@ -1,11 +1,13 @@
+import datetime
 import json
 
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from ..models import Labirinto
+from ..models import Labirinto,Corrida,Celula,EstadoAtual
 
+from corridas import _serializar_corrida_detalhe
 
 TAMANHOS_PERMITIDOS = {4, 8, 16}
 
@@ -68,3 +70,95 @@ def labirinto_detalhe(request, labirinto_id):
         return JsonResponse({"erro": "Labirinto nao encontrado."}, status=404)
 
     return JsonResponse(_serializar_labirinto(labirinto))
+
+
+# leitura de cada celula
+@csrf_exempt
+@require_http_methods(["POST"])
+def telemetria(request,corrida_id):
+    try:
+        corrida = Corrida.objects.get(id=corrida_id)
+    except Corrida.DoesNotExist:
+        return JsonResponse({"erro": "Corrida nao encontrada."}, status=404)
+    try:
+        dados = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"erro": "JSON invalido."}, status=400)
+
+    celula,_=Celula.objects.get_or_create(
+        labirinto_id=corrida.labirinto_id,
+        linha=dados.get("linha"),
+        coluna=dados.get("coluna"),
+        defaults={
+            "parede_norte": dados.get("parede_norte"),
+            "parede_sul": dados.get("parede_sul"),
+            "parede_leste": dados.get("parede_leste"),
+            "parede_oeste": dados.get("parede_oeste"),
+        }
+
+    )
+    registro=EstadoAtual.objects.create(
+        corrida_id=corrida,
+        celula_id=celula,
+        posicao_ordem=dados.get("posicao_ordem"),
+        x=dados.get("x"),
+        y=dados.get("y"),
+        direcao=dados.get("direcao"),
+        velocidade=dados.get("velocidade"),
+        bateria=dados.get("bateria"),
+    )
+    return JsonResponse({"id":registro.id}, status=201)
+
+@require_http_methods(["GET"])
+def estado_atual(request,corrida_id):
+    try:
+        corrida = Corrida.objects.get(id=corrida_id)
+    except Corrida.DoesNotExist:
+        return JsonResponse({"erro": "Corrida nao encontrada."}, status=404)
+
+    ultimo=(
+        EstadoAtual.objects.filter(corrida_id=corrida).order_by("-posicao_ordem").first()
+    )
+    if ultimo is None:
+        return JsonResponse({"erro":"Nenhuma telemetria encontrada."},status=404)
+
+    return JsonResponse({
+        "posicao_ordem": ultimo.posicao_ordem,
+        "x": ultimo.x,
+        "y": ultimo.y,
+        "direcao": ultimo.direcao,
+        "velocidade": ultimo.velocidade,
+        "bateria": ultimo.bateria,
+        "celula": {
+            "id": ultimo.celula_id.id,
+            "linha": ultimo.celula_id.linha,
+            "coluna": ultimo.celula_id.coluna,
+            "parede_norte": ultimo.celula_id.parede_norte,
+            "parede_sul": ultimo.celula_id.parede_sul,
+            "parede_leste": ultimo.celula_id.parede_leste,
+            "parede_oeste": ultimo.celula_id.parede_oeste,
+        }
+    }
+
+
+    )
+
+@csrf_exempt
+@require_http_methods(["PATCH"])
+def finalizar(request,corrida_id):
+    try:
+        corrida = Corrida.objects.get(id=corrida_id)
+    except Corrida.DoesNotExist:
+        return JsonResponse({"erro": "Corrida nao encontrada."}, status=404)
+    try:
+        dados = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"erro": "JSON invalido."}, status=400)
+
+    corrida.tempo_conclusao_sec=dados.get("tempo_conclusao_sec")
+    corrida.velocidade_med=dados.get("velocidade_media")
+    corrida.consumo_bat=dados.get("consumo_bateria")
+    corrida.desafio_concluido=dados.get("desafio_concluido",False)
+    corrida.finalizado_em=datetime.now(timezone=datetime.timezone.utc)
+    corrida.save()
+    return JsonResponse(_serializar_corrida_detalhe(corrida))

--- a/src/backend/telemetria/views/labirintos.py
+++ b/src/backend/telemetria/views/labirintos.py
@@ -1,0 +1,60 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from ..models import Labirinto
+
+
+TAMANHOS_PERMITIDOS = {4, 8, 16}
+
+
+def _serializar_labirinto(labirinto):
+    return {
+        "id": labirinto.id,
+        "nome": labirinto.nome,
+        "tamanho": labirinto.tamanho,
+        "created_at": labirinto.created_ad.isoformat(),
+    }
+
+
+@csrf_exempt
+@require_http_methods(["GET", "POST"])
+def labirintos(request):
+    if request.method == "GET":
+        registros = Labirinto.objects.order_by("id")
+        return JsonResponse(
+            [_serializar_labirinto(labirinto) for labirinto in registros],
+            safe=False,
+        )
+
+    try:
+        dados = json.loads(request.body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"erro": "JSON invalido."}, status=400)
+
+    if not isinstance(dados, dict):
+        return JsonResponse({"erro": "O corpo deve ser um objeto JSON."}, status=400)
+
+    nome = dados.get("nome")
+    tamanho = dados.get("tamanho")
+
+    if not isinstance(nome, str) or not nome.strip():
+        return JsonResponse({"erro": "O campo nome e obrigatorio."}, status=400)
+
+    nome = nome.strip()
+    if len(nome) > 256:
+        return JsonResponse(
+            {"erro": "O campo nome deve ter no maximo 256 caracteres."},
+            status=400,
+        )
+
+    if type(tamanho) is not int or tamanho not in TAMANHOS_PERMITIDOS:
+        return JsonResponse(
+            {"erro": "O campo tamanho deve ser 4, 8 ou 16."},
+            status=400,
+        )
+
+    labirinto = Labirinto.objects.create(nome=nome, tamanho=tamanho)
+    return JsonResponse(_serializar_labirinto(labirinto), status=201)

--- a/src/backend/telemetria/views/labirintos.py
+++ b/src/backend/telemetria/views/labirintos.py
@@ -58,3 +58,13 @@ def labirintos(request):
 
     labirinto = Labirinto.objects.create(nome=nome, tamanho=tamanho)
     return JsonResponse(_serializar_labirinto(labirinto), status=201)
+
+
+@require_http_methods(["GET"])
+def labirinto_detalhe(request, labirinto_id):
+    try:
+        labirinto = Labirinto.objects.get(id=labirinto_id)
+    except Labirinto.DoesNotExist:
+        return JsonResponse({"erro": "Labirinto nao encontrado."}, status=404)
+
+    return JsonResponse(_serializar_labirinto(labirinto))

--- a/src/backend/telemetria/views/labirintos.py
+++ b/src/backend/telemetria/views/labirintos.py
@@ -1,13 +1,17 @@
 import datetime
 import json
 
+from django.template.backends import django
+
+from django.utils import timezone
+
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 from ..models import Labirinto,Corrida,Celula,EstadoAtual
 
-from corridas import _serializar_corrida_detalhe
+from .corridas import _serializar_corrida_detalhe
 
 TAMANHOS_PERMITIDOS = {4, 8, 16}
 
@@ -86,7 +90,7 @@ def telemetria(request,corrida_id):
         return JsonResponse({"erro": "JSON invalido."}, status=400)
 
     celula,_=Celula.objects.get_or_create(
-        labirinto_id=corrida.labirinto_id,
+        labirinto_id=corrida.labitinto_id,
         linha=dados.get("linha"),
         coluna=dados.get("coluna"),
         defaults={
@@ -159,6 +163,6 @@ def finalizar(request,corrida_id):
     corrida.velocidade_med=dados.get("velocidade_media")
     corrida.consumo_bat=dados.get("consumo_bateria")
     corrida.desafio_concluido=dados.get("desafio_concluido",False)
-    corrida.finalizado_em=datetime.now(timezone=datetime.timezone.utc)
+    corrida.finalizado_em=timezone.now()
     corrida.save()
     return JsonResponse(_serializar_corrida_detalhe(corrida))


### PR DESCRIPTION
## Resumo
- Adiciona rotas em `/api/` para labirintos, corridas, telemetria, estado atual e finalização de corrida.
- Implementa views para criar/listar/buscar labirintos, criar/buscar corridas, registrar telemetria, consultar o estado atual e finalizar corridas.
- Reorganiza as views e testes de `telemetria` em módulos dedicados.
- Inclui testes para fluxos de sucesso e respostas de erro 400/404 nas novas rotas.

## Rotas principais
- `GET/POST /api/labirintos`
- `GET /api/labirintos/<id>`
- `POST /api/corridas`
- `GET /api/corridas/<id>`
- `POST /api/corridas/<id>/telemetria`
- `GET /api/corridas/<id>/estado-atual`
- `PATCH /api/corridas/<id>/finalizar`