### PR TITLE
feat(telemetria): módulo completo de telemetria do firmware integrado ao backend

### DIFF
--- a/docs/pages/software/tutorial-telemetria.md
+++ b/docs/pages/software/tutorial-telemetria.md
@@ -1,0 +1,699 @@
+# Tutorial de Telemetria — Micromouse
+
+> **Para quem é este tutorial?**
+> Qualquer pessoa do grupo que precise colocar o sistema de telemetria para funcionar do zero — da ESP32 até o dashboard.
+> Nenhum conhecimento avançado é necessário. Siga os passos na ordem.
+
+---
+
+## 1. O que é a Telemetria e Como Funciona
+
+A telemetria é o sistema que permite **ver o que o robô está fazendo em tempo real** no computador — posição no labirinto, bateria, paredes detectadas e muito mais.
+
+O fluxo completo é este:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         FLUXO DE DADOS                           │
+│                                                                   │
+│  ESP32 (robô)                                                     │
+│   ├─ Lê sensores IR (paredes)                                     │
+│   ├─ Lê bateria (ADC)                                            │
+│   ├─ Executa Flood Fill                                           │
+│   └─ Monta JSON → envia via WebSocket ───────────────┐           │
+│                                                       ↓           │
+│                                            Backend Django         │
+│                                             ├─ Recebe evento      │
+│                                             ├─ Salva no banco     │
+│                                             └─ Broadcast ─────┐  │
+│                                                                ↓  │
+│                                               Frontend React      │
+│                                                └─ Atualiza        │
+│                                                   Dashboard       │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Rede Wi-Fi utilizada
+
+A ESP32 **cria um hotspot próprio** chamado `rataturing`. O computador precisa se conectar a essa rede para que a comunicação funcione.
+
+```
+ESP32 (Access Point)
+  SSID    : rataturing
+  Senha   : 87654321
+  IP da ESP32 : 192.168.4.1
+  IP do PC    : 192.168.4.2  ← use este IP no firmware
+```
+
+### Eventos enviados pela ESP32
+
+| Evento | Quando é disparado |
+|--------|--------------------|
+| `run_started` | Uma vez, ao apertar a chave START |
+| `cell_discovered` | A cada nova célula visitada |
+| `run_finished` | Ao atingir o centro do labirinto |
+
+---
+
+## 2. Arquivos do Firmware
+
+Todos os arquivos do firmware estão em `src/firmware/`. Veja o que cada um faz:
+
+| Arquivo | Função |
+|---------|--------|
+| `main.cpp` | Ponto de entrada: `setup()` e `loop()` |
+| `Telemetry.h` / `Telemetry.cpp` | **Módulo de telemetria** — WebSocket + buffer FIFO |
+| `TelemetryTypes.h` | Estruturas de dados dos eventos |
+| `mouse.cpp` | Algoritmo Flood Fill + disparo dos eventos de telemetria |
+| `hal.h` | Mapeamento de todos os pinos da ESP32 |
+| `sensors.h` / `sensors.cpp` | Leitura dos sensores IR (TCRT5000) |
+| `motors.h` / `motors.cpp` | Controle da ponte H (TB6612FNG) + PID + encoders |
+| `battery.h` / `battery.cpp` | Leitura da bateria via ADC (divisor de tensão) |
+| `dip.h` / `dip.cpp` | Leitura da chave DIP (START / MAPA_4x4 / MAPA_8x8) |
+| `ota.h` / `ota.cpp` | Cria o hotspot Wi-Fi `rataturing` + servidor OTA |
+| `credentials.h` | SSID e senha da rede Wi-Fi (não alterar) |
+
+### ⚠️ Único arquivo que você PRECISA editar antes do upload
+
+**`src/firmware/Telemetry.cpp` — linha 25:**
+
+```cpp
+const char* host = "0.0.0.0"; // <-- COLOQUE O IP DO SEU PC AQUI
+```
+
+Descubra o IP do seu computador **depois de conectar na rede `rataturing`**:
+
+```bash
+# Linux / macOS
+hostname -I
+
+# Windows (no Prompt de Comando)
+ipconfig
+# procure o adaptador Wi-Fi e anote o "Endereço IPv4"
+```
+
+O IP vai ser algo como `192.168.4.2`. Substitua:
+
+```cpp
+const char* host = "192.168.4.2"; // exemplo — confirme o seu IP real
+```
+
+---
+
+## 3. Configurando o Firmware na Arduino IDE
+
+### 3.1 Pré-requisitos
+
+1. **Arduino IDE 2.x** instalada ([download aqui](https://www.arduino.cc/en/software))
+2. **Suporte ao ESP32** instalado:
+   - Abra: `Arquivo → Preferências`
+   - Em "URLs adicionais para Gerenciadores de Placas", cole:
+     ```
+     https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+     ```
+   - Abra: `Ferramentas → Placa → Gerenciador de Placas`
+   - Pesquise `esp32` e instale o pacote da **Espressif Systems**
+
+### 3.2 Instalando as Bibliotecas Necessárias
+
+Vá em `Sketch → Incluir Biblioteca → Gerenciar Bibliotecas` e instale as três bibliotecas abaixo:
+
+| Biblioteca | Autor | Para que serve |
+|------------|-------|----------------|
+| `ArduinoJson` | Benoit Blanchon | Criar e ler JSONs na ESP32 |
+| `WebSockets` | Markus Sattler | Conexão WebSocket com o backend |
+| `ElegantOTA` | Ayush Sharma | Atualização de firmware via Wi-Fi |
+
+> **Dica:** pesquise pelo nome exato na barra de busca do Gerenciador de Bibliotecas.
+
+### 3.3 Estrutura do Projeto na Arduino IDE
+
+A Arduino IDE trabalha com **sketches** (arquivos `.ino`). Para usar os arquivos `.cpp` e `.h` do projeto, crie uma pasta de sketch e coloque todos os arquivos dentro dela.
+
+**Estrutura esperada:**
+```
+MicromouseFirmware/
+├── MicromouseFirmware.ino   ← arquivo principal da IDE (pode estar vazio)
+├── main.cpp
+├── Telemetry.h
+├── Telemetry.cpp
+├── TelemetryTypes.h
+├── mouse.cpp
+├── hal.h
+├── sensors.h
+├── sensors.cpp
+├── motors.h
+├── motors.cpp
+├── battery.h
+├── battery.cpp
+├── dip.h
+├── dip.cpp
+├── ota.h
+├── ota.cpp
+└── credentials.h
+```
+
+**Como fazer:**
+
+1. Copie todos os arquivos de `src/firmware/` (ignore os `.md` e `.ino` de exemplo) para uma nova pasta chamada `MicromouseFirmware`
+2. Dentro dessa pasta, crie um arquivo chamado `MicromouseFirmware.ino` com o conteúdo vazio (a IDE precisa de um arquivo `.ino` para reconhecer como sketch; a lógica real está no `main.cpp`)
+3. Abra a pasta na Arduino IDE: `Arquivo → Abrir → selecione MicromouseFirmware.ino`
+
+### 3.4 Selecionando a Placa Correta
+
+`Ferramentas → Placa → ESP32 Arduino → ESP32 Dev Module`
+
+Configurações recomendadas:
+
+| Configuração | Valor |
+|---|---|
+| Upload Speed | 921600 |
+| CPU Frequency | 240MHz (WiFi/BT) |
+| Flash Size | 4MB (32Mb) |
+| Partition Scheme | Default 4MB with spiffs |
+
+### 3.5 Editando o IP do Backend
+
+Antes de fazer o upload, edite `Telemetry.cpp` (linha 25):
+
+```cpp
+// Substitua pelo IP do seu PC na rede rataturing
+const char* host = "192.168.4.2";
+const int port = 8000; // não altere
+```
+
+### 3.6 Fazendo o Upload
+
+1. Conecte a ESP32 ao computador via USB
+2. Selecione a porta: `Ferramentas → Porta → COMx` (Windows) ou `/dev/ttyUSB0` (Linux)
+3. Clique em **Upload** (→ ou `Ctrl+U`)
+4. Aguarde a mensagem `Done uploading`
+
+> Se aparecer erro de porta, tente segurar o botão **BOOT** da ESP32 enquanto o upload inicia.
+
+### 3.7 Monitorando via Serial Monitor
+
+Abra `Ferramentas → Monitor Serial` e configure para **115200 baud**.
+
+Saída esperada ao ligar:
+```
+=========================================
+Hotspot Wi-Fi criado! Rede: rataturing
+IP do Hotspot: 192.168.4.1
+=========================================
+=== Micromouse pronto ===
+Aguardando chave START...
+```
+
+Quando conectar ao backend e iniciar corrida:
+```
+[TEL] run_started | dim=16 bat=95%
+[TEL] cell_discovered | (0,0) dir=N bat=95%
+[TEL] cell_discovered | (0,1) dir=N bat=94%
+...
+[TEL] run_finished | bat=88%
+=== Corrida finalizada — aguardando reset ===
+```
+
+---
+
+## 4. Configurando o Firmware no PlatformIO
+
+O PlatformIO é uma alternativa mais profissional à Arduino IDE — gerencia bibliotecas automaticamente e tem melhor integração com o VS Code.
+
+### 4.1 Pré-requisitos
+
+1. **VS Code** instalado ([download](https://code.visualstudio.com/))
+2. Extensão **PlatformIO IDE** instalada:
+   - Abra o VS Code → Extensions (`Ctrl+Shift+X`)
+   - Pesquise `PlatformIO IDE` e instale
+
+### 4.2 Criando o Projeto
+
+1. Abra o VS Code
+2. Clique no ícone do PlatformIO na barra lateral (ícone de formiga 🐜)
+3. Clique em `New Project`:
+   - **Name:** `MicromouseFirmware`
+   - **Board:** pesquise e selecione `Espressif ESP32 Dev Module`
+   - **Framework:** `Arduino`
+4. Clique em **Finish** e aguarde a criação
+
+### 4.3 Copiando os Arquivos
+
+Copie todos os arquivos de `src/firmware/` para a pasta `src/` do projeto criado:
+
+```
+MicromouseFirmware/
+├── platformio.ini          ← configuração do projeto (editar a seguir)
+├── src/
+│   ├── main.cpp            ← substitua o que foi criado pela IDE
+│   ├── Telemetry.h
+│   ├── Telemetry.cpp
+│   ├── TelemetryTypes.h
+│   ├── mouse.cpp
+│   ├── hal.h
+│   ├── sensors.h
+│   ├── sensors.cpp
+│   ├── motors.h
+│   ├── motors.cpp
+│   ├── battery.h
+│   ├── battery.cpp
+│   ├── dip.h
+│   ├── dip.cpp
+│   ├── ota.h
+│   ├── ota.cpp
+│   └── credentials.h
+└── .pio/                   ← gerado automaticamente, não mexa
+```
+
+### 4.4 Configurando o `platformio.ini`
+
+Abra o arquivo `platformio.ini` na raiz do projeto e substitua o conteúdo por:
+
+```ini
+[env:esp32dev]
+platform  = espressif32
+board     = esp32dev
+framework = arduino
+
+; Velocidade de upload (mais rápido)
+upload_speed = 921600
+
+; Velocidade do monitor serial
+monitor_speed = 115200
+
+; Bibliotecas — o PlatformIO baixa automaticamente
+lib_deps =
+    bblanchon/ArduinoJson @ ^7.0.0
+    links2004/WebSockets @ ^2.4.1
+    ayushsharma82/ElegantOTA @ ^3.1.7
+```
+
+> O PlatformIO baixa e instala as bibliotecas automaticamente na primeira compilação. Você não precisa instalar nada manualmente.
+
+### 4.5 Editando o IP do Backend
+
+Mesmo processo da Arduino IDE: edite `src/Telemetry.cpp` linha 25:
+
+```cpp
+const char* host = "192.168.4.2"; // IP do seu PC na rede rataturing
+```
+
+### 4.6 Compilar, Upload e Monitor
+
+Todos os comandos ficam na barra inferior do VS Code com PlatformIO:
+
+| Botão | Atalho | Função |
+|-------|--------|--------|
+| ✔ (Build) | `Ctrl+Alt+B` | Compilar o firmware |
+| → (Upload) | `Ctrl+Alt+U` | Fazer upload para a ESP32 |
+| 🔌 (Monitor) | `Ctrl+Alt+S` | Abrir o monitor serial |
+
+---
+
+## 5. Configurando e Rodando o Backend
+
+O backend é um servidor **Django** com **Daphne** que recebe os eventos da ESP32 via WebSocket, salva no banco e retransmite para o dashboard em tempo real.
+
+### 5.1 Pré-requisitos
+
+- Python 3.10 ou superior instalado
+- `pip` disponível no terminal
+
+Verifique:
+```bash
+python --version   # deve ser 3.10+
+pip --version
+```
+
+### 5.2 Criando o Ambiente Virtual
+
+```bash
+# Na raiz do repositório
+cd /caminho/para/2026_1_PI1_Grupo02_Bruno
+
+python -m venv venv
+```
+
+Ativando o ambiente virtual:
+
+```bash
+# Linux / macOS
+source venv/bin/activate
+
+# Windows — Prompt de Comando
+venv\Scripts\activate.bat
+
+# Windows — PowerShell
+venv\Scripts\Activate.ps1
+```
+
+> ✅ Você saberá que funcionou quando aparecer `(venv)` no início da linha do terminal.
+
+### 5.3 Instalando as Dependências
+
+```bash
+pip install -r src/backend/requirements.txt
+```
+
+As principais dependências são:
+
+| Pacote | Versão | Função |
+|--------|--------|--------|
+| Django | 6.0.5 | Framework web principal |
+| channels | 4.0.0 | Suporte a WebSocket no Django |
+| daphne | 4.0.0 | Servidor ASGI (necessário para WebSocket) |
+| asgiref | 3.11.1 | Camada de compatibilidade ASGI |
+
+### 5.4 Criando o Banco de Dados
+
+Execute este comando apenas na **primeira vez** (ou se apagar o arquivo `db.sqlite3`):
+
+```bash
+cd src/backend
+python manage.py migrate
+```
+
+Saída esperada:
+```
+Operations to perform:
+  Apply all migrations: admin, auth, contenttypes, sessions, telemetria
+Running migrations:
+  Applying telemetria.0001_initial... OK
+  ...
+```
+
+### 5.5 Iniciando o Servidor com Daphne
+
+O sistema de telemetria usa **WebSocket**, que exige um servidor ASGI. O Daphne é o servidor ASGI configurado no projeto e é iniciado automaticamente pelo `manage.py runserver`:
+
+```bash
+# Certifique-se de estar na pasta certa com o venv ativo
+cd src/backend
+python manage.py runserver 0.0.0.0:8000
+```
+
+Ou diretamente com o Daphne:
+```bash
+cd src/backend
+daphne -b 0.0.0.0 -p 8000 config.asgi:application
+```
+
+> **Por que `0.0.0.0`?**
+> Isso faz o servidor escutar em **todas as interfaces de rede** do computador — tanto no `localhost` quanto no IP da rede `rataturing` (`192.168.4.2`). Se usar `127.0.0.1`, a ESP32 não consegue alcançar o servidor.
+
+Saída esperada:
+```
+Starting ASGI/Daphne version 4.0.0 development server at http://0.0.0.0:8000/
+```
+
+### 5.6 Rotas WebSocket Disponíveis
+
+O backend expõe dois canais WebSocket:
+
+| Rota | Quem se conecta | Função |
+|------|----------------|--------|
+| `ws://192.168.4.2:8000/ws/firmware/` | ESP32 | Recebe eventos de telemetria |
+| `ws://127.0.0.1:8000/ws/corrida/live/` | Frontend (browser) | Transmite eventos em tempo real |
+
+**Como funciona internamente:**
+
+```
+ESP32 ──────► ws/firmware/ ──► FirmwareConsumer ──► Salva no banco
+                                                  └──► Broadcast "corrida_live"
+                                                             │
+Frontend ◄── ws/corrida/live/ ◄── CorridaConsumer ◄─────────┘
+```
+
+---
+
+## 6. Conectando Tudo — Passo a Passo Completo
+
+Siga esta ordem **sempre** que for testar o sistema completo:
+
+### Ordem de inicialização
+
+```
+Passo 1 ─── Inicie o backend no terminal
+Passo 2 ─── Ligue o robô (ele cria a rede rataturing)
+Passo 3 ─── Conecte o PC na rede rataturing
+Passo 4 ─── Confirme o IP do PC (deve ser 192.168.4.2)
+Passo 5 ─── Confirme que o Telemetry.cpp tem o IP correto
+Passo 6 ─── Ative a chave START no robô
+```
+
+### Passo 1 — Iniciar o Backend
+
+Abra um terminal, ative o venv e execute:
+
+```bash
+source venv/bin/activate         # Linux/macOS
+# ou: venv\Scripts\activate.bat  # Windows
+
+cd src/backend
+python manage.py runserver 0.0.0.0:8000
+```
+
+Deixe este terminal aberto durante toda a sessão.
+
+### Passo 2 — Ligar o Robô
+
+- Ligue o robô ou conecte via USB para ver o Serial Monitor
+- Ele vai criar automaticamente a rede `rataturing`
+- O Serial Monitor mostrará: `IP do Hotspot: 192.168.4.1`
+
+### Passo 3 — Conectar o PC na Rede da ESP32
+
+No seu computador, vá nas configurações de Wi-Fi e conecte à rede:
+- **Nome:** `rataturing`
+- **Senha:** `87654321`
+
+### Passo 4 — Verificar o IP Recebido
+
+```bash
+hostname -I   # Linux/macOS — anote o IP no formato 192.168.4.x
+ipconfig      # Windows — procure "Adaptador Wi-Fi" → "Endereço IPv4"
+```
+
+O IP deve ser `192.168.4.2` (padrão). Se for diferente, use o IP mostrado.
+
+### Passo 5 — Confirmar o Firmware
+
+Se precisou alterar o IP, edite `Telemetry.cpp` e faça novo upload.
+
+Quando tudo estiver certo, o terminal do backend mostrará:
+```
+WebSocket CONNECT /ws/firmware/
+```
+
+### Passo 6 — Iniciar a Corrida
+
+Ative a chave **START** (pino 27). O Serial Monitor mostrará:
+
+```
+=== START ativado — iniciando corrida ===
+[TEL] run_started | dim=16 bat=95%
+[TEL] cell_discovered | (0,0) dir=N bat=95%
+[TEL] cell_discovered | (0,1) dir=N bat=94%
+...
+[TEL] run_finished | bat=88%
+```
+
+E o terminal do backend confirmará o recebimento de cada evento.
+
+---
+
+## 7. Validando sem o Robô Físico (Simulador Python)
+
+Se você não tiver o robô disponível, pode testar o backend com o simulador:
+
+```bash
+# Com o backend rodando em outro terminal e o venv ativo:
+cd src/backend
+python telemetria/tests/simulador_ws.py
+```
+
+Saída esperada:
+```
+Conectando em ws://localhost:8000/ws/firmware/ ...
+Conexão estabelecida.
+
+  [OK] run_started — ack=1, corrida_id=3
+  [OK] cell_discovered (0,0) dir=N — ack=2
+  [OK] cell_discovered (1,0) dir=L — ack=3
+  [OK] cell_discovered (2,0) dir=L — ack=4
+  ...
+  [OK] optimal_path_calculated — ack=10
+  [OK] fast_run_started — ack=11
+  [OK] run_finished — ack=12
+
+Todos os eventos enviados com sucesso. corrida_id=3
+```
+
+---
+
+## 8. Verificando os Dados no Banco de Dados
+
+Para confirmar que os eventos estão sendo salvos corretamente:
+
+```bash
+cd src/backend
+python manage.py shell
+```
+
+No shell interativo:
+```python
+from telemetria.models import Corrida, Celula, EstadoAtual
+
+# Ver todas as corridas registradas
+Corrida.objects.all().values('id', 'iniciado_em', 'finalizado_em', 'desafio_concluido')
+
+# Ver a última corrida
+c = Corrida.objects.last()
+print(f"Corrida #{c.id} | Início: {c.iniciado_em} | Concluída: {c.desafio_concluido}")
+
+# Quantas células foram mapeadas nessa corrida
+estados = EstadoAtual.objects.filter(corrida_id=c).count()
+print(f"Células visitadas: {estados}")
+
+# Ver as posições em ordem
+for e in EstadoAtual.objects.filter(corrida_id=c).order_by('posicao_ordem'):
+    print(f"  Passo {e.posicao_ordem}: ({e.x},{e.y}) dir={e.direcao} bat={e.bateria:.0f}%")
+```
+
+---
+
+## 9. Referência dos Eventos JSON
+
+### `run_started` — Início da corrida
+
+```json
+{
+  "event_id": 1,
+  "id_corrida": 0,
+  "timestamp_ms": 0,
+  "tipo": "run_started",
+  "payload": {
+    "dimensao": 16,
+    "tentativa": 1,
+    "bateria": 95
+  }
+}
+```
+
+**ACK retornado pelo backend:**
+```json
+{ "ack": 1, "corrida_id": 7 }
+```
+
+> A partir deste ACK, o firmware usa `"id_corrida": 7` em **todos** os próximos eventos.
+
+---
+
+### `cell_discovered` — Nova célula visitada
+
+```json
+{
+  "event_id": 2,
+  "id_corrida": 7,
+  "timestamp_ms": 1340,
+  "tipo": "cell_discovered",
+  "payload": {
+    "x": 0,
+    "y": 1,
+    "linha": 1,
+    "coluna": 0,
+    "parede_norte": false,
+    "parede_sul": true,
+    "parede_leste": false,
+    "parede_oeste": true,
+    "direcao": "N",
+    "velocidade": 0.38,
+    "bateria": 94.0
+  }
+}
+```
+
+**ACK:** `{ "ack": 2 }`
+
+> `linha` = alias de `y` | `coluna` = alias de `x` (exigidos pelo backend)
+
+---
+
+### `run_finished` — Corrida finalizada
+
+```json
+{
+  "event_id": 47,
+  "id_corrida": 7,
+  "timestamp_ms": 38500,
+  "tipo": "run_finished",
+  "payload": {
+    "sucesso": true,
+    "v_med": 0.38,
+    "bateria": 88.0
+  }
+}
+```
+
+**ACK:** `{ "ack": 47 }`
+
+---
+
+## 10. Chaves DIP — Configuração do Labirinto
+
+| Pino (HAL) | Chave | Função |
+|-----------|-------|--------|
+| 27 | `START` | Liga/desliga a corrida |
+| 14 | `MAPA_4X4` | Usa labirinto 4×4 |
+| 13 | `MAPA_8X8` | Usa labirinto 8×8 |
+
+Se nenhuma chave de mapa estiver ativa, o robô assume labirinto **16×16** (padrão de competição).
+
+---
+
+## 11. Atualização OTA (sem fio, sem cabo USB)
+
+Após o primeiro upload via USB, você pode enviar novas versões do firmware **pelo Wi-Fi**:
+
+1. Conecte o PC na rede `rataturing`
+2. Acesse no navegador: `http://192.168.4.1/update`
+3. Gere o arquivo `.bin` do firmware:
+   - **Arduino IDE:** `Sketch → Exportar Binário Compilado` → o `.bin` fica na pasta do sketch
+   - **PlatformIO:** clique em **Build** → o arquivo fica em `.pio/build/esp32dev/firmware.bin`
+4. Faça o upload do `.bin` pela página web e aguarde o reinício
+
+---
+
+## 12. Solução de Problemas
+
+### ESP32 não conecta ao backend
+
+| Sintoma | Causa | Solução |
+|---------|-------|---------|
+| Serial não mostra "WebSocket conectado" | IP errado em `Telemetry.cpp` | Confirme com `hostname -I` e faça upload |
+| Backend não exibe nenhum `CONNECT` | Backend não está rodando com `0.0.0.0` | Execute `runserver 0.0.0.0:8000` |
+| PC não recebe IP `192.168.4.x` | Não conectou à rede `rataturing` | Verifique o Wi-Fi do computador |
+| Erro 400 Bad Request no backend | `ALLOWED_HOSTS` faltando IPs | Confirme `settings.py` com os IPs da rede |
+
+### Erros de compilação
+
+| Erro | Solução |
+|------|---------|
+| `ArduinoJson.h: No such file` | Instale `ArduinoJson` no Gerenciador de Bibliotecas |
+| `WebSocketsClient.h: No such file` | Instale `WebSockets` no Gerenciador de Bibliotecas |
+| `ElegantOTA.h: No such file` | Instale `ElegantOTA` no Gerenciador de Bibliotecas |
+| `std::array` / `constexpr` errors | Selecione a placa `ESP32 Dev Module` (não Arduino Uno) |
+| Porta não encontrada | Instale driver CP2102 ou CH340 para o conversor USB |
+
+### Dados não aparecem no banco
+
+| Sintoma | Causa | Solução |
+|---------|-------|---------|
+| `"erro": "Corrida nao iniciada"` no log | `cell_discovered` chegou antes do ACK de `run_started` | Verifique a conexão WebSocket — o primeiro ACK deve chegar |
+| Banco vazio após corrida | `migrate` não foi executado | Execute `python manage.py migrate` |
+| `id_corrida: 0` em todos os eventos | ACK do `run_started` não chegou ao firmware | Verifique o IP e a conectividade entre ESP32 e backend |
+
+---
+
+*Para mais detalhes sobre a arquitetura do protocolo, consulte [`telemetria.md`](./telemetria.md) na mesma pasta.*

--- a/src/backend/config/settings.py
+++ b/src/backend/config/settings.py
@@ -25,7 +25,17 @@ SECRET_KEY = 'django-insecure-aq*66p%5&!xy46!zum9a9^gd811=dcv#b&_=9j@gh1qm!ql7eo
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    'localhost',
+    '127.0.0.1',
+    # Rede AP criada pela ESP32 ("rataturing"):
+    #   192.168.4.1 = IP da própria ESP32 (gateway da rede)
+    #   192.168.4.2 = IP padrão do PC que se conecta à rede da ESP32
+    '192.168.4.1',
+    '192.168.4.2',
+    # Para desenvolvimento: libera qualquer host local
+    '0.0.0.0',
+]
 
 
 # Application definition

--- a/src/firmware/API_2.cpp
+++ b/src/firmware/API_2.cpp
@@ -1,0 +1,110 @@
+#include "API_2.h"
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int API::mazeWidth() {
+    std::cout << "mazeWidth" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return std::atoi(response.c_str());
+}
+
+int API::mazeHeight() {
+    std::cout << "mazeHeight" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return std::atoi(response.c_str());
+}
+
+bool API::wallFront() {
+    std::cout << "wallFront" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return response == "true";
+}
+
+bool API::wallRight() {
+    std::cout << "wallRight" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return response == "true";
+}
+
+bool API::wallLeft() {
+    std::cout << "wallLeft" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return response == "true";
+}
+
+void API::moveForward(int distance) {
+    std::cout << "moveForward";
+    if (distance != 1) {
+        std::cout << " " << distance;
+    }
+    std::cout << std::endl;
+    std::string response;
+    std::cin >> response;
+    if (response != "ack") {
+        std::cerr << response << std::endl;
+        throw std::runtime_error("moveForward falhou: resposta inesperada do simulador");
+    }
+}
+
+void API::turnRight() {
+    std::cout << "turnRight" << std::endl;
+    std::string ack;
+    std::cin >> ack;
+}
+
+void API::turnLeft() {
+    std::cout << "turnLeft" << std::endl;
+    std::string ack;
+    std::cin >> ack;
+}
+
+void API::setWall(int x, int y, char direction) {
+    std::cout << "setWall " << x << " " << y << " " << direction << std::endl;
+}
+
+void API::clearWall(int x, int y, char direction) {
+    std::cout << "clearWall " << x << " " << y << " " << direction << std::endl;
+}
+
+void API::setColor(int x, int y, char color) {
+    std::cout << "setColor " << x << " " << y << " " << color << std::endl;
+}
+
+void API::clearColor(int x, int y) {
+    std::cout << "clearColor " << x << " " << y << std::endl;
+}
+
+void API::clearAllColor() {
+    std::cout << "clearAllColor" << std::endl;
+}
+
+void API::setText(int x, int y, const std::string& text) {
+    std::cout << "setText " << x << " " << y << " " << text << std::endl;
+}
+
+void API::clearText(int x, int y) {
+    std::cout << "clearText " << x << " " << y << std::endl;
+}
+
+void API::clearAllText() {
+    std::cout << "clearAllText" << std::endl;
+}
+
+bool API::wasReset() {
+    std::cout << "wasReset" << std::endl;
+    std::string response;
+    std::cin >> response;
+    return response == "true";
+}
+
+void API::ackReset() {
+    std::cout << "ackReset" << std::endl;
+    std::string ack;
+    std::cin >> ack;
+}

--- a/src/firmware/API_2.h
+++ b/src/firmware/API_2.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+class API {
+
+public:
+
+    static int mazeWidth();
+    static int mazeHeight();
+
+    static bool wallFront();
+    static bool wallRight();
+    static bool wallLeft();
+
+    static void moveForward(int distance = 1);
+    static void turnRight();
+    static void turnLeft();
+
+    static void setWall(int x, int y, char direction);
+    static void clearWall(int x, int y, char direction);
+
+    static void setColor(int x, int y, char color);
+    static void clearColor(int x, int y);
+    static void clearAllColor();
+
+    static void setText(int x, int y, const std::string& text);
+    static void clearText(int x, int y);
+    static void clearAllText();
+
+    static bool wasReset();
+    static void ackReset();
+
+};

--- a/src/firmware/Telemetry.cpp
+++ b/src/firmware/Telemetry.cpp
@@ -3,6 +3,33 @@
 #include "TelemetryTypes.h"
 #include <ArduinoJson.h>
 
+int Telemetry::head = 0;
+int Telemetry::tail = 0;
+int Telemetry::count = 0;
+String Telemetry::eventBuffer[50];
+
+void Telemetry::adicionarAoBuffer(String json){
+    if(count < BUFFER_SIZE){
+        eventBuffer[tail] = json;
+        tail = (tail + 1) % BUFFER_SIZE;
+        count++;
+    }
+}
+
+bool Telemetry::processarBuffer(){
+    if(count > 0){
+        String json = eventBuffer[head];
+        // funcao de envio do websocket vai ser chamada aqui
+        // if(websocket.send(json)){
+            head = (head + 1) % BUFFER_SIZE;
+            count--;
+            return true;
+
+        //}
+    }
+    return false;
+}
+
 
 static uint32_t next_event_id = 1;
 
@@ -32,6 +59,7 @@ void Telemetry::sendRunStarted(int dimensao, int tentativa, int bateria) {
     
     String output;
     serializeJson(doc, output);
+    adicionarAoBuffer(output);
 }
 
 void Telemetry::sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool p_leste, bool p_oeste, const char* direcao, float velocidade, float bateria) {

--- a/src/firmware/Telemetry.cpp
+++ b/src/firmware/Telemetry.cpp
@@ -1,0 +1,67 @@
+#include <Arduino.h>
+#include "Telemetry.h"
+#include "TelemetryTypes.h"
+#include <ArduinoJson.h>
+
+
+static uint32_t next_event_id = 1;
+
+static void montarJsonBase(JsonDocument& doc, const char* tipo) {
+    doc["event_id"] = next_event_id++;
+    doc["id_corrida"] = 1;
+    doc["timestamp_ms"] = millis();
+    doc["tipo"] = tipo;
+}
+
+void Telemetry::init() {
+    
+}
+
+void Telemetry::process() {
+    
+}
+
+void Telemetry::sendRunStarted(int dimensao, int tentativa, int bateria) {
+    StaticJsonDocument<256> doc;
+    montarJsonBase(doc, "run_started");
+    
+    JsonObject payload = doc.createNestedObject("payload");
+    payload["dimensao"] = dimensao;
+    payload["tentativa"] = tentativa;
+    payload["bateria"] = bateria;
+    
+    String output;
+    serializeJson(doc, output);
+}
+
+void Telemetry::sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool p_leste, bool p_oeste, const char* direcao, float velocidade, float bateria) {
+    StaticJsonDocument<512> doc;
+    montarJsonBase(doc, "cell_discovered");
+    
+    JsonObject payload = doc.createNestedObject("payload");
+    payload["x"] = x;
+    payload["y"] = y;
+    payload["parede_norte"] = p_norte;
+    payload["parede_sul"] = p_sul;
+    payload["parede_leste"] = p_leste;
+    payload["parede_oeste"] = p_oeste;
+    payload["direcao"] = direcao;
+    payload["velocidade"] = velocidade;
+    payload["bateria"] = bateria;
+    
+    String output;
+    serializeJson(doc, output);
+}
+
+void Telemetry::sendRunFinished(bool sucesso, float v_med, float bateria) {
+    StaticJsonDocument<256> doc;
+    montarJsonBase(doc, "run_finished");
+    
+    JsonObject payload = doc.createNestedObject("payload");
+    payload["sucesso"] = sucesso;
+    payload["v_med"] = v_med;
+    payload["bateria"] = bateria;
+    
+    String output;
+    serializeJson(doc, output);
+}

--- a/src/firmware/Telemetry.cpp
+++ b/src/firmware/Telemetry.cpp
@@ -9,8 +9,21 @@ int Telemetry::count = 0;
 String Telemetry::eventBuffer[50];
 WebSocketsClient Telemetry::webSocket;
 
-const char* host = "192.168.1.100"; // MUDAR PARA O IP DO SEU BACKEND
-const int port = 8000;              // Porta padrão do Django
+// ─── CONFIGURAÇÃO DE REDE ─────────────────────────────────────────────────
+// Defina abaixo o IP do computador onde o backend Django está rodando.
+//
+// Modo AP (padrão): a ESP32 cria a rede "rataturing" (credentials.h).
+//   → Conecte o PC nessa rede.
+//   → O IP do PC nessa rede costuma ser 192.168.4.2
+//   → Defina: host = "192.168.4.2"
+//
+// Modo STA (alternativo): modifique ota.cpp para conectar em um roteador.
+//   → Use o IP local do PC na rede do roteador (ex: "192.168.1.15")
+//   → Descubra com: hostname -I  (Linux) ou ipconfig (Windows)
+//
+// TODO: substitua o valor abaixo antes de fazer o upload para a ESP32
+const char* host = "0.0.0.0"; // <-- CONFIGURE O IP DO BACKEND AQUI
+const int port = 8000;        // Porta padrão do Django (não alterar)
 
 static uint32_t next_event_id = 1;
 

--- a/src/firmware/Telemetry.cpp
+++ b/src/firmware/Telemetry.cpp
@@ -7,6 +7,56 @@ int Telemetry::head = 0;
 int Telemetry::tail = 0;
 int Telemetry::count = 0;
 String Telemetry::eventBuffer[50];
+WebSocketsClient Telemetry::webSocket;
+
+const char* host = "192.168.1.100"; // MUDAR PARA O IP DO SEU BACKEND
+const int port = 8000;              // Porta padrão do Django
+
+static uint32_t next_event_id = 1;
+
+static void montarJsonBase(JsonDocument& doc, const char* tipo) {
+    doc["event_id"] = next_event_id++;
+    doc["id_corrida"] = 1;
+    doc["timestamp_ms"] = millis();
+    doc["tipo"] = tipo;
+}
+
+void Telemetry::init() {
+    webSocket.begin(host, port, "/ws/firmware/");
+    webSocket.onEvent(Telemetry::webSocketEvent);
+    webSocket.setReconnectInterval(5000);
+}
+
+void Telemetry::process() {
+    webSocket.loop();
+    if (webSocket.isConnected()) {
+        processarBuffer();
+    }
+}
+
+void Telemetry::webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
+    switch(type) {
+        case WStype_TEXT: {
+            StaticJsonDocument<64> doc;
+            DeserializationError error = deserializeJson(doc, payload);
+            if (!error && doc.containsKey("ack")) {
+                // O servidor confirmou o recebimento do evento mais antigo!
+                // Agora sim, removemos do buffer com segurança.
+                if(count > 0) {
+                    head = (head + 1) % BUFFER_SIZE;
+                    count--;
+                }
+            }
+            break;
+        }
+        case WStype_DISCONNECTED:
+            // Log: conexão perdida
+            break;
+        case WStype_CONNECTED:
+            // Log: conectado ao servidor
+            break;
+    }
+}
 
 void Telemetry::adicionarAoBuffer(String json){
     if(count < BUFFER_SIZE){
@@ -19,33 +69,12 @@ void Telemetry::adicionarAoBuffer(String json){
 bool Telemetry::processarBuffer(){
     if(count > 0){
         String json = eventBuffer[head];
-        // funcao de envio do websocket vai ser chamada aqui
-        // if(websocket.send(json)){
-            head = (head + 1) % BUFFER_SIZE;
-            count--;
+        // Tentamos enviar. Se o WiFi estiver ok, ele envia.
+        if(webSocket.sendTXT(json)){
             return true;
-
-        //}
+        }
     }
     return false;
-}
-
-
-static uint32_t next_event_id = 1;
-
-static void montarJsonBase(JsonDocument& doc, const char* tipo) {
-    doc["event_id"] = next_event_id++;
-    doc["id_corrida"] = 1;
-    doc["timestamp_ms"] = millis();
-    doc["tipo"] = tipo;
-}
-
-void Telemetry::init() {
-    
-}
-
-void Telemetry::process() {
-    
 }
 
 void Telemetry::sendRunStarted(int dimensao, int tentativa, int bateria) {
@@ -79,6 +108,7 @@ void Telemetry::sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool 
     
     String output;
     serializeJson(doc, output);
+    adicionarAoBuffer(output);
 }
 
 void Telemetry::sendRunFinished(bool sucesso, float v_med, float bateria) {
@@ -92,4 +122,5 @@ void Telemetry::sendRunFinished(bool sucesso, float v_med, float bateria) {
     
     String output;
     serializeJson(doc, output);
+    adicionarAoBuffer(output);
 }

--- a/src/firmware/Telemetry.cpp
+++ b/src/firmware/Telemetry.cpp
@@ -26,10 +26,14 @@ const char* host = "0.0.0.0"; // <-- CONFIGURE O IP DO BACKEND AQUI
 const int port = 8000;        // Porta padrão do Django (não alterar)
 
 static uint32_t next_event_id = 1;
+// id_corrida_atual é atualizado via ACK do backend após run_started.
+// O backend retorna { "ack": N, "corrida_id": X } ao criar a corrida no banco.
+// Enquanto não houver corrida ativa, permanece 0.
+static uint32_t corrida_id_atual = 0;
 
 static void montarJsonBase(JsonDocument& doc, const char* tipo) {
     doc["event_id"] = next_event_id++;
-    doc["id_corrida"] = 1;
+    doc["id_corrida"] = corrida_id_atual;
     doc["timestamp_ms"] = millis();
     doc["tipo"] = tipo;
 }
@@ -50,11 +54,16 @@ void Telemetry::process() {
 void Telemetry::webSocketEvent(WStype_t type, uint8_t * payload, size_t length) {
     switch(type) {
         case WStype_TEXT: {
-            StaticJsonDocument<64> doc;
+            // Aumentamos o buffer para 128 bytes para comportar o campo corrida_id.
+            StaticJsonDocument<128> doc;
             DeserializationError error = deserializeJson(doc, payload);
             if (!error && doc.containsKey("ack")) {
-                // O servidor confirmou o recebimento do evento mais antigo!
-                // Agora sim, removemos do buffer com segurança.
+                // Se o ACK vier acompanhado de corrida_id (resposta ao run_started),
+                // atualiza o id da corrida ativa para os próximos eventos.
+                if (doc.containsKey("corrida_id")) {
+                    corrida_id_atual = doc["corrida_id"].as<uint32_t>();
+                }
+                // Remove o evento confirmado do buffer FIFO.
                 if(count > 0) {
                     head = (head + 1) % BUFFER_SIZE;
                     count--;
@@ -111,6 +120,8 @@ void Telemetry::sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool 
     JsonObject payload = doc.createNestedObject("payload");
     payload["x"] = x;
     payload["y"] = y;
+    payload["linha"]  = y;
+    payload["coluna"] = x;
     payload["parede_norte"] = p_norte;
     payload["parede_sul"] = p_sul;
     payload["parede_leste"] = p_leste;

--- a/src/firmware/Telemetry.h
+++ b/src/firmware/Telemetry.h
@@ -1,0 +1,24 @@
+#ifndef TELEMETRY_H
+#define TELEMETRY_H
+
+/**
+ * @brief Interface de telemetria para o Micromouse.
+ * 
+ * Este módulo gerencia o envio de eventos para o backend via WebSocket,
+ * implementando buffer em memória para casos de desconexão.
+ */
+class Telemetry {
+public:
+    static void init();
+
+    static void process(); 
+    
+    static void sendRunStarted(int dimensao, int tentativa, int bateria);
+    static void sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool p_leste, bool p_oeste, const char* direcao, float velocidade, float bateria);
+    static void sendRunFinished(bool sucesso, float v_med, float bateria);
+
+private:
+    
+};
+
+#endif // TELEMETRY_H

--- a/src/firmware/Telemetry.h
+++ b/src/firmware/Telemetry.h
@@ -1,6 +1,8 @@
 #ifndef TELEMETRY_H
 #define TELEMETRY_H
 
+#include <WebSocketsClient.h>
+
 /**
  * @brief Interface de telemetria para o Micromouse.
  * 
@@ -18,6 +20,8 @@ public:
     static void sendRunFinished(bool sucesso, float v_med, float bateria);
     
 private:
+    static void webSocketEvent(WStype_t type, uint8_t * payload, size_t length);
+    static WebSocketsClient webSocket;
     static void adicionarAoBuffer(String json);
     static bool processarBuffer();
 

--- a/src/firmware/Telemetry.h
+++ b/src/firmware/Telemetry.h
@@ -16,8 +16,16 @@ public:
     static void sendRunStarted(int dimensao, int tentativa, int bateria);
     static void sendCellDiscovered(int x, int y, bool p_norte, bool p_sul, bool p_leste, bool p_oeste, const char* direcao, float velocidade, float bateria);
     static void sendRunFinished(bool sucesso, float v_med, float bateria);
-
+    
 private:
+    static void adicionarAoBuffer(String json);
+    static bool processarBuffer();
+
+    static const int BUFFER_SIZE = 50;
+    static String eventBuffer[BUFFER_SIZE];
+    static int head;
+    static int tail;
+    static int count;
     
 };
 

--- a/src/firmware/TelemetryTypes.h
+++ b/src/firmware/TelemetryTypes.h
@@ -1,0 +1,46 @@
+#ifndef TELEMETRY_TYPES_H
+#define TELEMETRY_TYPES_H
+
+#include <stdint.h>
+
+// Estrutura para representar coordenadas da rota
+struct Coordinate {
+    int x;
+    int y;
+};
+
+// Payload para run_started
+struct RunStartedPayload {
+    int dimensao;
+    int tentativa;
+    float bateria;
+};
+
+// Payload para cell_discovered
+struct CellDiscoveredPayload {
+    int x;
+    int y;
+    bool parede_norte;
+    bool parede_sul;
+    bool parede_leste;
+    bool parede_oeste;
+    const char* direcao;
+    float velocidade;
+    float bateria;
+};
+
+// Payload para optimal_path_calculated
+// O tamanho máximo da rota dependerá do labirinto (ex: 256 células max).
+struct OptimalPathPayload {
+    Coordinate rota[256];
+    int tamanho_rota;
+};
+
+// Payload para run_finished
+struct RunFinishedPayload {
+    bool sucesso;
+    float v_med;
+    float bateria;
+};
+
+#endif

--- a/src/firmware/caso_de_teste_telemetria.cpp
+++ b/src/firmware/caso_de_teste_telemetria.cpp
@@ -1,0 +1,55 @@
+#include <Arduino.h>
+#include "hal.h"
+#include "sensors.h"
+#include "battery.h"
+#include "dip.h"
+#include "ota.h"
+#include "Telemetry.h"
+
+static constexpr float VEL_ESTIMADA_MS_TESTE =
+    (VEL_BASE / 255.0f) *
+    ((360.0f / PULSOSPORVOLTA) *
+     (3.14159f * (DIAMETRO_RODA_MM / 1000.0f)));
+
+void telemetria_run_teste() {
+    int dimensao = 16;
+    if (mapa_4x4()) dimensao = 4;
+    else if (mapa_8x8()) dimensao = 8;
+
+    int bat_inicial = battery_porcentagem();
+    Telemetry::sendRunStarted(dimensao, 99, bat_inicial);
+    Serial.printf("[TEL-TESTE] run_started | dim=%d bat=%d%%\n", dimensao, bat_inicial);
+
+    unsigned long ultima_checada = millis();
+
+    for (int passo = 0; passo < 10; passo++) {
+        Telemetry::process();
+        ota_loop();
+
+        bool p_norte = sensor_parede_frente();
+        bool p_sul   = false;
+        bool p_leste = sensor_parede_direita();
+        bool p_oeste = sensor_parede_esquerda();
+        float bat    = (float)battery_porcentagem();
+
+        Telemetry::sendCellDiscovered(
+            passo, 0,
+            p_norte, p_sul, p_leste, p_oeste,
+            "N", VEL_ESTIMADA_MS_TESTE, bat
+        );
+        Serial.printf("[TEL-TESTE] cell_discovered | (%d,0) bat=%.0f%%\n", passo, bat);
+
+        if (millis() - ultima_checada >= 30000) {
+            Serial.printf("[BAT] Nível: %d%%\n", battery_porcentagem());
+            ultima_checada = millis();
+        }
+
+        delay(500);
+    }
+
+    float bat_final = (float)battery_porcentagem();
+    Telemetry::sendRunFinished(true, VEL_ESTIMADA_MS_TESTE, bat_final);
+    Telemetry::process();
+    Serial.printf("[TEL-TESTE] run_finished | bat=%.0f%%\n", bat_final);
+    Serial.println("[TEL-TESTE] Teste concluido.");
+}

--- a/src/firmware/corrida_com_telemetria.cpp
+++ b/src/firmware/corrida_com_telemetria.cpp
@@ -1,0 +1,225 @@
+#include <Arduino.h>
+#include <cstring>
+#include <array>
+#include <algorithm>
+#include "hal.h"
+#include "motors.h"
+#include "sensors.h"
+#include "battery.h"
+#include "dip.h"
+#include "ota.h"
+#include "Telemetry.h"
+
+constexpr int TAM_CT      = 16;
+constexpr int MAX_DIST_CT = 255;
+
+constexpr char PCT_NORTE = 0x1;
+constexpr char PCT_LESTE = 0x2;
+constexpr char PCT_SUL   = 0x4;
+constexpr char PCT_OESTE = 0x8;
+
+enum class DirecaoCT : int { norte = 0, leste = 1, sul = 2, oeste = 3 };
+constexpr int NUM_DIR_CT = 4;
+constexpr int idxCT(DirecaoCT d) { return static_cast<int>(d); }
+
+static constexpr float VEL_ESTIMADA_MS =
+    (VEL_BASE / 255.0f) *
+    ((360.0f / PULSOSPORVOLTA) *
+     (3.14159f * (DIAMETRO_RODA_MM / 1000.0f)));
+
+class MicromouseComTelemetria {
+public:
+    MicromouseComTelemetria() { reset(); }
+
+    void run() {
+        int dimensao = 16;
+        if (mapa_4x4()) dimensao = 4;
+        else if (mapa_8x8()) dimensao = 8;
+
+        int bat_inicial = battery_porcentagem();
+        Telemetry::sendRunStarted(dimensao, tentativa_atual, bat_inicial);
+        tentativa_atual++;
+        Serial.printf("[TEL] run_started | dim=%d bat=%d%%\n", dimensao, bat_inicial);
+
+        detectar_paredes();
+        calcular_distancias();
+        ultima_checada = millis();
+
+        while (!centro(pos_x, pos_y)) {
+            Telemetry::process();
+
+            detectar_paredes();
+
+            bool p_norte  = tem_parede(pos_x, pos_y, DirecaoCT::norte);
+            bool p_sul    = tem_parede(pos_x, pos_y, DirecaoCT::sul);
+            bool p_leste  = tem_parede(pos_x, pos_y, DirecaoCT::leste);
+            bool p_oeste  = tem_parede(pos_x, pos_y, DirecaoCT::oeste);
+            const char* dir_str   = direcao_para_str(direcao);
+            float       bat_atual = (float)battery_porcentagem();
+
+            Telemetry::sendCellDiscovered(
+                pos_x, pos_y,
+                p_norte, p_sul, p_leste, p_oeste,
+                dir_str, VEL_ESTIMADA_MS, bat_atual
+            );
+            Serial.printf("[TEL] cell_discovered | (%d,%d) dir=%s bat=%.0f%%\n",
+                          pos_x, pos_y, dir_str, bat_atual);
+
+            if (millis() - ultima_checada >= INTERVALO_BATERIA) {
+                Serial.printf("[BAT] Nível: %d%%\n", battery_porcentagem());
+                ultima_checada = millis();
+            }
+
+            calcular_distancias();
+            melhor_celula();
+            ota_loop();
+        }
+
+        float bat_final = (float)battery_porcentagem();
+        Telemetry::sendRunFinished(true, VEL_ESTIMADA_MS, bat_final);
+        Telemetry::process();
+        Serial.printf("[TEL] run_finished | bat=%.0f%%\n", bat_final);
+
+        motors_parar();
+    }
+
+private:
+    unsigned long ultima_checada          = 0;
+    const unsigned long INTERVALO_BATERIA = 30000;
+    int       distancia[TAM_CT][TAM_CT];
+    char      paredes[TAM_CT][TAM_CT];
+    int       pos_x = 0, pos_y = 0;
+    DirecaoCT direcao = DirecaoCT::norte;
+    int       tentativa_atual = 1;
+
+    static constexpr std::array<int, NUM_DIR_CT> move_x = { 0,  1,  0, -1 };
+    static constexpr std::array<int, NUM_DIR_CT> move_y = { 1,  0, -1,  0 };
+    static constexpr std::array<DirecaoCT, NUM_DIR_CT> oposto = {
+        DirecaoCT::sul, DirecaoCT::oeste, DirecaoCT::norte, DirecaoCT::leste
+    };
+
+    void reset() {
+        pos_x   = 0;
+        pos_y   = 0;
+        direcao = DirecaoCT::norte;
+        std::memset(paredes, 0, sizeof(paredes));
+        inicializar_bordas();
+    }
+
+    void inicializar_bordas() {
+        for (int i = 0; i < TAM_CT; i++) {
+            paredes[i][TAM_CT - 1] |= PCT_NORTE;
+            paredes[i][0]          |= PCT_SUL;
+            paredes[TAM_CT - 1][i] |= PCT_LESTE;
+            paredes[0][i]          |= PCT_OESTE;
+        }
+    }
+
+    bool centro(int x, int y) const {
+        return (x == 7 || x == 8) && (y == 7 || y == 8);
+    }
+
+    bool tem_parede(int x, int y, DirecaoCT d) const {
+        return (paredes[x][y] & (1 << idxCT(d))) != 0;
+    }
+
+    static const char* direcao_para_str(DirecaoCT d) {
+        switch (d) {
+            case DirecaoCT::norte: return "N";
+            case DirecaoCT::leste: return "L";
+            case DirecaoCT::sul:   return "S";
+            case DirecaoCT::oeste: return "O";
+            default:               return "N";
+        }
+    }
+
+    void calcular_distancias() {
+        for (int x = 0; x < TAM_CT; x++)
+            for (int y = 0; y < TAM_CT; y++)
+                distancia[x][y] = centro(x, y) ? 0 : MAX_DIST_CT;
+
+        bool alteracao = true;
+        while (alteracao) {
+            alteracao = false;
+            for (int x = 0; x < TAM_CT; x++) {
+                for (int y = 0; y < TAM_CT; y++) {
+                    if (centro(x, y)) continue;
+                    int melhor_vizinho = MAX_DIST_CT;
+                    auto verificar = [&](DirecaoCT d, int nx, int ny) {
+                        if (!tem_parede(x, y, d) && nx >= 0 && nx < TAM_CT && ny >= 0 && ny < TAM_CT)
+                            melhor_vizinho = std::min(melhor_vizinho, distancia[nx][ny]);
+                    };
+                    verificar(DirecaoCT::norte, x, y + 1);
+                    verificar(DirecaoCT::sul,   x, y - 1);
+                    verificar(DirecaoCT::leste, x + 1, y);
+                    verificar(DirecaoCT::oeste, x - 1, y);
+
+                    int nova = (melhor_vizinho == MAX_DIST_CT) ? MAX_DIST_CT : melhor_vizinho + 1;
+                    if (nova < distancia[x][y]) {
+                        distancia[x][y] = nova;
+                        alteracao = true;
+                    }
+                }
+            }
+        }
+    }
+
+    void adicionar_parede(int x, int y, DirecaoCT d) {
+        paredes[x][y] |= (1 << idxCT(d));
+        int nx = x + move_x[idxCT(d)];
+        int ny = y + move_y[idxCT(d)];
+        if (nx >= 0 && nx < TAM_CT && ny >= 0 && ny < TAM_CT)
+            paredes[nx][ny] |= (1 << idxCT(oposto[idxCT(d)]));
+    }
+
+    DirecaoCT relativa_para_absoluta(DirecaoCT dir_mouse, int giro) const {
+        return static_cast<DirecaoCT>((idxCT(dir_mouse) + giro) % NUM_DIR_CT);
+    }
+
+    void detectar_paredes() {
+        if (sensor_parede_frente())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 0));
+        if (sensor_parede_direita())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 1));
+        if (sensor_parede_esquerda())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 3));
+    }
+
+    bool melhor_celula() {
+        int melhor_direcao  = -1;
+        int menor_distancia = MAX_DIST_CT + 1;
+
+        for (int d = 0; d < NUM_DIR_CT; d++) {
+            if (tem_parede(pos_x, pos_y, static_cast<DirecaoCT>(d))) continue;
+            int nx = pos_x + move_x[d];
+            int ny = pos_y + move_y[d];
+            if (distancia[nx][ny] < menor_distancia) {
+                menor_distancia = distancia[nx][ny];
+                melhor_direcao  = d;
+            }
+        }
+
+        if (melhor_direcao == -1) return false;
+
+        while (idxCT(direcao) != melhor_direcao) {
+            int diferenca = (melhor_direcao - idxCT(direcao) + NUM_DIR_CT) % NUM_DIR_CT;
+            if (diferenca == 1) {
+                motors_girar_direita();
+                direcao = static_cast<DirecaoCT>((idxCT(direcao) + 1) % NUM_DIR_CT);
+            } else {
+                motors_girar_esquerda();
+                direcao = static_cast<DirecaoCT>((idxCT(direcao) + 3) % NUM_DIR_CT);
+            }
+        }
+
+        motors_avancar_celula();
+        pos_x += move_x[melhor_direcao];
+        pos_y += move_y[melhor_direcao];
+        return true;
+    }
+};
+
+void micromouse_run_com_telemetria() {
+    MicromouseComTelemetria mouse;
+    mouse.run();
+}

--- a/src/firmware/main.cpp
+++ b/src/firmware/main.cpp
@@ -1,231 +1,81 @@
+/**
+ * @file main.cpp
+ * @brief Ponto de entrada do firmware do Micromouse ESP32 com telemetria integrada.
+ *
+ * Fluxo de execução:
+ *
+ *  setup()
+ *    ├─ sensors_init()       → configura pinos dos sensores IR (TCRT5000)
+ *    ├─ dip_init()           → configura chave DIP START/MAPA_4X4/MAPA_8X8
+ *    ├─ battery_init()       → configura pino ADC do divisor de tensão da bateria
+ *    ├─ motors_init()        → configura ponte H (TB6612FNG), PWM e encoders
+ *    ├─ ota_init()           → sobe hotspot Wi-Fi ("rataturing") e servidor OTA
+ *    └─ Telemetry::init()    → abre conexão WebSocket com o backend
+ *
+ *  loop()
+ *    ├─ ota_loop()           → mantém servidor OTA e Wi-Fi vivos
+ *    ├─ Telemetry::process() → processa fila de eventos e mantém WebSocket ativo
+ *    └─ start() == HIGH?
+ *         └─ micromouse_run() → executa navegação Flood Fill com telemetria
+ *
+ * ATENÇÃO: Antes de fazer upload, configure o IP do backend em Telemetry.cpp:
+ *   const char* host = "IP_DO_SEU_COMPUTADOR";  // Ex: "192.168.4.2"
+ *
+ * O hotspot da ESP32 usa a rede definida em credentials.h (padrão: "rataturing").
+ * Conecte o computador nessa rede e execute o backend Django antes de ligar o robô.
+ */
+
 #include <Arduino.h>
-#include <cstring>
-#include <array>
-#include <algorithm>
-#include <stdexcept>
 #include "hal.h"
 #include "motors.h"
 #include "sensors.h"
 #include "battery.h"
 #include "ota.h"
 #include "dip.h"
+#include "Telemetry.h"
 
-// seguindo a mesma lógica do código do simulador mms mas agora com funções declaradas e não apenas api do simulador
-constexpr int TAM = 16;
-constexpr int MAX = 255;
-constexpr char P_NORTE = 0x1;
-constexpr char P_LESTE = 0x2;
-constexpr char P_SUL   = 0x4;
-constexpr char P_OESTE = 0x8;
-enum class Direcao : int { norte = 0, leste = 1, sul = 2, oeste = 3};
-constexpr int NUM_DIRECOES = 4;
-constexpr int idx(Direcao d) { return static_cast<int>(d);}
-
-class Micromouse {
-public:
-    Micromouse() {reset();}
-
-    void run() {
-        detectar_paredes();
-        calcular_distancias();
-        ultima_checada = millis();
-        while (!centro(pos_x, pos_y)) {
-            detectar_paredes();
-            calcular_distancias();
-            melhor_celula();
-            if (millis() - ultima_checada >= INTERVALO_BATERIA) {
-                int bat = battery_porcentagem();
-                Serial.print("Nivel da Bateria: ");
-                Serial.print(bat);
-                Serial.println("%");
-                
-                ultima_checada = millis(); // Reseta o cronômetro
-            }
-            ota_loop(); // mantém o servidor OTA respondendo mesmo durante a corrida
-        }
-        // chegou ao centro para os motores
-        motors_parar();
-    }
-
-private:
-    unsigned long ultima_checada = 0;
-    const unsigned long INTERVALO_BATERIA = 30000;
-    int  distancia[TAM][TAM];
-    char paredes[TAM][TAM];
-    int  pos_x, pos_y;
-    Direcao direcao;
-    static constexpr std::array<int, NUM_DIRECOES> move_x = {0, 1,  0, -1};
-    static constexpr std::array<int, NUM_DIRECOES> move_y = {1, 0, -1, 0};
-    static constexpr std::array<Direcao, NUM_DIRECOES> oposto = {Direcao::sul, Direcao::oeste, Direcao::norte, Direcao::leste
-    };
-    
-
-    void reset() {
-        pos_x  = 0;
-        pos_y  = 0;
-        direcao  = Direcao::norte;
-        std::memset(paredes, 0, sizeof(paredes));
-        inicializar_bordas();
-    }
-
-    void inicializar_bordas() {
-        for (int i = 0; i < TAM; i++) {
-            paredes[i][TAM - 1]  |= P_NORTE;
-            paredes[i][0]  |= P_SUL;
-            paredes[TAM - 1][i] |= P_LESTE;
-            paredes[0][i]  |= P_OESTE;
-        }
-    }
-
-    bool centro(int x, int y) const {
-        return (x == 7 || x == 8) && (y == 7 || y == 8);
-    }
-
-    bool tem_parede(int x, int y, Direcao d) const {
-        return (paredes[x][y] & (1 << idx(d))) != 0;
-    }
-
-    void calcular_distancias() {
-        for (int x = 0; x < TAM; x++)
-            for (int y = 0; y < TAM; y++)
-                distancia[x][y] = centro(x, y) ? 0 : MAX;
-        bool alteracao = true;
-        while (alteracao) {
-            alteracao = false;
-            for (int x = 0; x < TAM; x++) {
-                for (int y = 0; y < TAM; y++) {
-                    if (centro(x, y)) continue;
-
-                    int melhor_vizinho = MAX;
-                    auto verificar = [&](Direcao d, int nx, int ny) {
-                        if (!tem_parede(x, y, d) && nx >= 0 && nx < TAM && ny >= 0 && ny < TAM)
-                            melhor_vizinho = std::min(melhor_vizinho, distancia[nx][ny]);
-                    };
-                    verificar(Direcao::norte, x, y + 1);
-                    verificar(Direcao::sul, x, y - 1);
-                    verificar(Direcao::leste, x + 1, y);
-                    verificar(Direcao::oeste, x - 1, y);
-
-                    int nova = (melhor_vizinho == MAX) ? MAX : melhor_vizinho + 1;
-                    if (nova < distancia[x][y]) {
-                        distancia[x][y] = nova;
-                        alteracao = true;
-                    }
-                }
-            }
-        }
-    }
-    // registra uma parede detectada na memória do labirinto
-    void adicionar_parede(int x, int y, Direcao d) {
-        paredes[x][y] |= (1 << idx(d));
-        int nx = x + move_x[idx(d)];
-        int ny = y + move_y[idx(d)];
-        if (nx >= 0 && nx < TAM && ny >= 0 && ny < TAM)
-            paredes[nx][ny] |= (1 << idx(oposto[idx(d)]));
-    }
-
-    Direcao relativa_para_absoluta(Direcao dir_mouse, int giro) const {
-        return static_cast<Direcao>((idx(dir_mouse) + giro) % NUM_DIRECOES);
-    }
-
-    // detecção de paredes
-    void detectar_paredes() {
-        if (sensor_parede_frente())
-            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 0));
-        if (sensor_parede_direita())
-            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 1));
-        if (sensor_parede_esquerda())
-            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 3));
-    }
-
-    // antes chamava apenas algumas funcoes de virar para a direita e para a esquerda agora chama funcoes reais do robo real
-    bool melhor_celula() {
-        int melhor_direcao  = -1;
-        int menor_distancia  = MAX + 1;
-
-        for (int d = 0; d < NUM_DIRECOES; d++) {
-            auto dir = static_cast<Direcao>(d);
-            if (tem_parede(pos_x, pos_y, dir)) continue;
-            int nx = pos_x + move_x[d];
-            int ny = pos_y + move_y[d];
-            if (distancia[nx][ny] < menor_distancia) {
-                menor_distancia = distancia[nx][ny];
-                melhor_direcao  = d;
-            }
-        }
-
-        if (melhor_direcao == -1) return false;
-        // gira até apontar para a direção desejada
-        while (idx(direcao) != melhor_direcao) {
-            int diferenca = (melhor_direcao - idx(direcao) + NUM_DIRECOES) % NUM_DIRECOES;
-            if (diferenca == 1) {
-                motors_girar_direita();                         
-                direcao = static_cast<Direcao>((idx(direcao) + 1) % NUM_DIRECOES);
-            } else {
-                motors_girar_esquerda();                        
-                direcao = static_cast<Direcao>((idx(direcao) + 3) % NUM_DIRECOES);
-            }
-        }
-        motors_avancar_celula();                               
-        pos_x += move_x[melhor_direcao];
-        pos_y += move_y[melhor_direcao];
-        return true;
-    }
-};
-
-bool teste_executado = false; 
+// Declaração da função de navegação definida em mouse.cpp
+void micromouse_run();
 
 void setup() {
     Serial.begin(115200);
+
+    // Inicialização do hardware
     sensors_init();
     dip_init();
     battery_init();
     motors_init();
+
+    // Inicialização da rede: sobe hotspot Wi-Fi "rataturing" e servidor OTA em /update
     ota_init();
+
+    // Inicialização da telemetria: abre WebSocket para o backend Django
+    // ATENÇÃO: o host em Telemetry.cpp deve apontar para o IP correto do servidor
+    Telemetry::init();
+
+    Serial.println("=== Micromouse pronto ===");
+    Serial.println("Aguardando chave START...");
+    dip_print();
 }
 
 void loop() {
-    ota_loop(); 
+    // Mantém o servidor OTA respondendo (necessário para atualizações OTA)
+    ota_loop();
 
-    if (start() && !teste_executado) {
-        
-        int vel_teste = 150; // Velocidade segura 
-        
-        // 1. TESTE ESQUERDA - FRENTE
-        digitalWrite(MOT_ESQ_INA1, HIGH);
-        digitalWrite(MOT_ESQ_INA2, LOW);
-        ledcWrite(MOT_ESQ_PWMA, vel_teste);
-        delay(2000);
-        ledcWrite(MOT_ESQ_PWMA, 0); // Desliga
-        delay(2000); // Pausa para você observar
+    // Processa o buffer de telemetria e mantém a conexão WebSocket ativa
+    Telemetry::process();
 
-        // 2. TESTE ESQUERDA - TRÁS
-        digitalWrite(MOT_ESQ_INA1, LOW);
-        digitalWrite(MOT_ESQ_INA2, HIGH);
-        ledcWrite(MOT_ESQ_PWMA, vel_teste);
-        delay(2000);
-        ledcWrite(MOT_ESQ_PWMA, 0);
-        delay(2000);
+    // Aguarda a chave DIP START (pino 27) ser ativada para iniciar a corrida
+    if (start()) {
+        Serial.println("=== START ativado — iniciando corrida ===");
+        micromouse_run();
+        Serial.println("=== Corrida finalizada — aguardando reset ===");
 
-        // 3. TESTE DIREITA - FRENTE
-        digitalWrite(MOT_DIR_INB1, HIGH);
-        digitalWrite(MOT_DIR_INB2, LOW);
-        ledcWrite(MOT_DIR_PWMB, vel_teste);
-        delay(2000);
-        ledcWrite(MOT_DIR_PWMB, 0);
-        delay(2000);
-
-        // 4. TESTE DIREITA - TRÁS
-        digitalWrite(MOT_DIR_INB1, LOW);
-        digitalWrite(MOT_DIR_INB2, HIGH);
-        ledcWrite(MOT_DIR_PWMB, vel_teste);
-        delay(2000);
-        ledcWrite(MOT_DIR_PWMB, 0);
-
-        teste_executado = true; // Trava para não repetir
-    }
-
-    if (!start()) {
-        teste_executado = false; // Rearma quando você desligar a chave
+        // Aguarda o operador desligar a chave START antes de permitir nova corrida
+        while (start()) {
+            ota_loop();
+            Telemetry::process();
+            delay(100);
+        }
     }
 }

--- a/src/firmware/main.cpp
+++ b/src/firmware/main.cpp
@@ -16,7 +16,7 @@
  *    ├─ ota_loop()           → mantém servidor OTA e Wi-Fi vivos
  *    ├─ Telemetry::process() → processa fila de eventos e mantém WebSocket ativo
  *    └─ start() == HIGH?
- *         └─ micromouse_run() → executa navegação Flood Fill com telemetria
+ *         └─ micromouse_run_com_telemetria() → executa navegação Flood Fill com telemetria
  *
  * ATENÇÃO: Antes de fazer upload, configure o IP do backend em Telemetry.cpp:
  *   const char* host = "IP_DO_SEU_COMPUTADOR";  // Ex: "192.168.4.2"
@@ -34,8 +34,7 @@
 #include "dip.h"
 #include "Telemetry.h"
 
-// Declaração da função de navegação definida em mouse.cpp
-void micromouse_run();
+void micromouse_run_com_telemetria();
 
 void setup() {
     Serial.begin(115200);
@@ -68,7 +67,7 @@ void loop() {
     // Aguarda a chave DIP START (pino 27) ser ativada para iniciar a corrida
     if (start()) {
         Serial.println("=== START ativado — iniciando corrida ===");
-        micromouse_run();
+        micromouse_run_com_telemetria();
         Serial.println("=== Corrida finalizada — aguardando reset ===");
 
         // Aguarda o operador desligar a chave START antes de permitir nova corrida

--- a/src/firmware/mouse.cpp
+++ b/src/firmware/mouse.cpp
@@ -1,0 +1,300 @@
+/**
+ * @file mouse.cpp
+ * @brief Lógica de navegação do Micromouse (Flood Fill) integrada com telemetria real.
+ *
+ * Esta implementação é derivada do código da branch `software-embarcados` e adiciona
+ * os eventos de telemetria nas passagens corretas do algoritmo de navegação:
+ *
+ *  - sendRunStarted()     → disparado uma vez ao início de cada corrida
+ *  - sendCellDiscovered() → disparado a cada nova célula mapeada pelos sensores IR
+ *  - sendRunFinished()    → disparado ao atingir o centro do labirinto
+ *
+ * Os dados passados para a telemetria vêm diretamente das funções reais do hardware:
+ *  - Paredes  : sensor_parede_frente/direita/esquerda() via detectar_paredes()
+ *  - Bateria  : battery_porcentagem()
+ *  - Velocidade: constante física derivada de VEL_BASE e DIAMETRO_RODA_MM
+ */
+
+#include <Arduino.h>
+#include <cstring>
+#include <array>
+#include <algorithm>
+#include "hal.h"
+#include "motors.h"
+#include "sensors.h"
+#include "battery.h"
+#include "dip.h"
+#include "Telemetry.h"
+
+// ─── Constantes do labirinto ───────────────────────────────────────────────
+constexpr int TAM = 16;
+constexpr int MAX_DIST = 255;
+
+// Bits de parede armazenados em paredes[x][y]
+constexpr char P_NORTE = 0x1;
+constexpr char P_LESTE = 0x2;
+constexpr char P_SUL   = 0x4;
+constexpr char P_OESTE = 0x8;
+
+enum class Direcao : int { norte = 0, leste = 1, sul = 2, oeste = 3 };
+constexpr int NUM_DIRECOES = 4;
+constexpr int idx(Direcao d) { return static_cast<int>(d); }
+
+// Velocidade estimada em m/s baseada na constante VEL_BASE e no diâmetro da roda
+// VEL_BASE=160 (PWM) → ~70% da velocidade máxima; roda ø44mm → circunferência=138mm
+// Com 360 pulsos/volta e ~1000 pulsos/s em velocidade base ≈ 0,38 m/s
+static constexpr float VEL_ESTIMADA_MS = (VEL_BASE / 255.0f) * 
+                                          ((360.0f / PULSOSPORVOLTA) * 
+                                           (3.14159f * (DIAMETRO_RODA_MM / 1000.0f)));
+
+// ─── Classe Micromouse ─────────────────────────────────────────────────────
+
+class Micromouse {
+public:
+    Micromouse() { reset(); }
+
+    /**
+     * @brief Executa uma corrida completa: do ponto (0,0) até o centro do labirinto.
+     *
+     * Sequência:
+     *  1. Lê dimensão pelas chaves DIP e envia RunStarted.
+     *  2. Loop: detecta paredes → envia CellDiscovered → Flood Fill → move.
+     *  3. Ao chegar no centro, envia RunFinished e para os motores.
+     */
+    void run() {
+        // --- 1. Determinar dimensão pelo DIP switch ---
+        int dimensao = 16;
+        if (mapa_4x4()) dimensao = 4;
+        else if (mapa_8x8()) dimensao = 8;
+
+        // --- 2. Evento: Corrida Iniciada ---
+        int bat_inicial = battery_porcentagem();
+        Telemetry::sendRunStarted(dimensao, tentativa_atual, bat_inicial);
+        tentativa_atual++;
+
+        Serial.printf("[TEL] run_started | dim=%d bat=%d%%\n", dimensao, bat_inicial);
+
+        // Mapeia paredes de borda e calcula distâncias iniciais
+        detectar_paredes();
+        calcular_distancias();
+        ultima_checada = millis();
+
+        // --- 3. Loop de navegação ---
+        while (!centro(pos_x, pos_y)) {
+            // Mantém o WebSocket ativo em segundo plano
+            Telemetry::process();
+
+            // Detecta paredes na célula atual usando os sensores IR
+            detectar_paredes();
+
+            // Lê o estado atual das paredes desta célula do mapa interno
+            bool p_norte = tem_parede(pos_x, pos_y, Direcao::norte);
+            bool p_sul   = tem_parede(pos_x, pos_y, Direcao::sul);
+            bool p_leste = tem_parede(pos_x, pos_y, Direcao::leste);
+            bool p_oeste = tem_parede(pos_x, pos_y, Direcao::oeste);
+
+            // Converte enum Direcao para string ("N", "L", "S", "O")
+            const char* dir_str = direcao_para_str(direcao);
+
+            // Lê bateria real via ADC (divisor de tensão na hal.h)
+            float bat_atual = (float)battery_porcentagem();
+
+            // --- 4. Evento: Célula Descoberta ---
+            Telemetry::sendCellDiscovered(
+                pos_x, pos_y,
+                p_norte, p_sul, p_leste, p_oeste,
+                dir_str,
+                VEL_ESTIMADA_MS,
+                bat_atual
+            );
+
+            Serial.printf("[TEL] cell_discovered | (%d,%d) dir=%s bat=%.0f%%\n",
+                          pos_x, pos_y, dir_str, bat_atual);
+
+            // Loga bateria periodicamente no Serial (a cada 30s)
+            if (millis() - ultima_checada >= INTERVALO_BATERIA) {
+                Serial.printf("[BAT] Nível: %d%%\n", battery_porcentagem());
+                ultima_checada = millis();
+            }
+
+            calcular_distancias();
+            melhor_celula();   // Move o robô fisicamente para a próxima célula
+
+            ota_loop();        // Mantém o servidor OTA respondendo durante a corrida
+        }
+
+        // --- 5. Evento: Corrida Finalizada ---
+        float bat_final = (float)battery_porcentagem();
+        Telemetry::sendRunFinished(true, VEL_ESTIMADA_MS, bat_final);
+        // Garante envio do último evento antes de parar
+        Telemetry::process();
+
+        Serial.printf("[TEL] run_finished | bat=%.0f%%\n", bat_final);
+
+        motors_parar();
+    }
+
+private:
+    unsigned long ultima_checada = 0;
+    const unsigned long INTERVALO_BATERIA = 30000;  // 30 segundos
+    int   distancia[TAM][TAM];
+    char  paredes[TAM][TAM];
+    int   pos_x = 0, pos_y = 0;
+    Direcao direcao = Direcao::norte;
+    int tentativa_atual = 1;
+
+    // Vetores de deslocamento por direção: norte→+y, leste→+x, sul→-y, oeste→-x
+    static constexpr std::array<int, NUM_DIRECOES> move_x = { 0,  1,  0, -1 };
+    static constexpr std::array<int, NUM_DIRECOES> move_y = { 1,  0, -1,  0 };
+
+    static constexpr std::array<Direcao, NUM_DIRECOES> oposto = {
+        Direcao::sul, Direcao::oeste, Direcao::norte, Direcao::leste
+    };
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    void reset() {
+        pos_x   = 0;
+        pos_y   = 0;
+        direcao = Direcao::norte;
+        std::memset(paredes, 0, sizeof(paredes));
+        inicializar_bordas();
+    }
+
+    void inicializar_bordas() {
+        for (int i = 0; i < TAM; i++) {
+            paredes[i][TAM - 1] |= P_NORTE;
+            paredes[i][0]       |= P_SUL;
+            paredes[TAM - 1][i] |= P_LESTE;
+            paredes[0][i]       |= P_OESTE;
+        }
+    }
+
+    bool centro(int x, int y) const {
+        return (x == 7 || x == 8) && (y == 7 || y == 8);
+    }
+
+    bool tem_parede(int x, int y, Direcao d) const {
+        return (paredes[x][y] & (1 << idx(d))) != 0;
+    }
+
+    // Converte o enum Direcao para o código de string esperado pela telemetria
+    static const char* direcao_para_str(Direcao d) {
+        switch (d) {
+            case Direcao::norte: return "N";
+            case Direcao::leste: return "L";
+            case Direcao::sul:   return "S";
+            case Direcao::oeste: return "O";
+            default:             return "N";
+        }
+    }
+
+    // ── Flood Fill ────────────────────────────────────────────────────────
+
+    void calcular_distancias() {
+        for (int x = 0; x < TAM; x++)
+            for (int y = 0; y < TAM; y++)
+                distancia[x][y] = centro(x, y) ? 0 : MAX_DIST;
+
+        bool alteracao = true;
+        while (alteracao) {
+            alteracao = false;
+            for (int x = 0; x < TAM; x++) {
+                for (int y = 0; y < TAM; y++) {
+                    if (centro(x, y)) continue;
+                    int melhor_vizinho = MAX_DIST;
+                    auto verificar = [&](Direcao d, int nx, int ny) {
+                        if (!tem_parede(x, y, d) && nx >= 0 && nx < TAM && ny >= 0 && ny < TAM)
+                            melhor_vizinho = std::min(melhor_vizinho, distancia[nx][ny]);
+                    };
+                    verificar(Direcao::norte, x, y + 1);
+                    verificar(Direcao::sul,   x, y - 1);
+                    verificar(Direcao::leste, x + 1, y);
+                    verificar(Direcao::oeste, x - 1, y);
+
+                    int nova = (melhor_vizinho == MAX_DIST) ? MAX_DIST : melhor_vizinho + 1;
+                    if (nova < distancia[x][y]) {
+                        distancia[x][y] = nova;
+                        alteracao = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Detecção de paredes (sensores IR reais) ───────────────────────────
+
+    void adicionar_parede(int x, int y, Direcao d) {
+        paredes[x][y] |= (1 << idx(d));
+        int nx = x + move_x[idx(d)];
+        int ny = y + move_y[idx(d)];
+        if (nx >= 0 && nx < TAM && ny >= 0 && ny < TAM)
+            paredes[nx][ny] |= (1 << idx(oposto[idx(d)]));
+    }
+
+    Direcao relativa_para_absoluta(Direcao dir_mouse, int giro) const {
+        return static_cast<Direcao>((idx(dir_mouse) + giro) % NUM_DIRECOES);
+    }
+
+    /**
+     * @brief Lê os três sensores IR (frente, direita, esquerda) e registra
+     *        as paredes detectadas no mapa interno do labirinto.
+     *
+     * sensor_parede_frente()    → sensor_cm(IR_FRENTE)   < DIST_FRONTAL_LIMITE_CM
+     * sensor_parede_direita()   → sensor_cm(IR_DIREITA)  < DIST_SEM_PAREDE_CM
+     * sensor_parede_esquerda()  → sensor_cm(IR_ESQUERDA) < DIST_SEM_PAREDE_CM
+     */
+    void detectar_paredes() {
+        if (sensor_parede_frente())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 0));
+        if (sensor_parede_direita())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 1));
+        if (sensor_parede_esquerda())
+            adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 3));
+    }
+
+    // ── Movimento (motores reais com PID e encoders) ──────────────────────
+
+    bool melhor_celula() {
+        int melhor_direcao  = -1;
+        int menor_distancia = MAX_DIST + 1;
+
+        for (int d = 0; d < NUM_DIRECOES; d++) {
+            auto dir = static_cast<Direcao>(d);
+            if (tem_parede(pos_x, pos_y, dir)) continue;
+            int nx = pos_x + move_x[d];
+            int ny = pos_y + move_y[d];
+            if (distancia[nx][ny] < menor_distancia) {
+                menor_distancia = distancia[nx][ny];
+                melhor_direcao  = d;
+            }
+        }
+
+        if (melhor_direcao == -1) return false;
+
+        // Gira o robô para apontar à direção desejada usando motors_girar_*()
+        while (idx(direcao) != melhor_direcao) {
+            int diferenca = (melhor_direcao - idx(direcao) + NUM_DIRECOES) % NUM_DIRECOES;
+            if (diferenca == 1) {
+                motors_girar_direita();
+                direcao = static_cast<Direcao>((idx(direcao) + 1) % NUM_DIRECOES);
+            } else {
+                motors_girar_esquerda();
+                direcao = static_cast<Direcao>((idx(direcao) + 3) % NUM_DIRECOES);
+            }
+        }
+
+        // Avança uma célula completa (controlado por encoders + PID)
+        motors_avancar_celula();
+        pos_x += move_x[melhor_direcao];
+        pos_y += move_y[melhor_direcao];
+        return true;
+    }
+};
+
+// ─── Ponto de entrada da corrida (chamado pelo main.cpp) ──────────────────
+
+void micromouse_run() {
+    Micromouse mouse;
+    mouse.run();
+}

--- a/src/firmware/mouse.cpp
+++ b/src/firmware/mouse.cpp
@@ -1,20 +1,3 @@
-/**
- * @file mouse.cpp
- * @brief Lógica de navegação do Micromouse (Flood Fill) integrada com telemetria real.
- *
- * Esta implementação é derivada do código da branch `software-embarcados` e adiciona
- * os eventos de telemetria nas passagens corretas do algoritmo de navegação:
- *
- *  - sendRunStarted()     → disparado uma vez ao início de cada corrida
- *  - sendCellDiscovered() → disparado a cada nova célula mapeada pelos sensores IR
- *  - sendRunFinished()    → disparado ao atingir o centro do labirinto
- *
- * Os dados passados para a telemetria vêm diretamente das funções reais do hardware:
- *  - Paredes  : sensor_parede_frente/direita/esquerda() via detectar_paredes()
- *  - Bateria  : battery_porcentagem()
- *  - Velocidade: constante física derivada de VEL_BASE e DIAMETRO_RODA_MM
- */
-
 #include <Arduino.h>
 #include <cstring>
 #include <array>
@@ -24,13 +7,10 @@
 #include "sensors.h"
 #include "battery.h"
 #include "dip.h"
-#include "Telemetry.h"
 
-// ─── Constantes do labirinto ───────────────────────────────────────────────
-constexpr int TAM = 16;
+constexpr int TAM      = 16;
 constexpr int MAX_DIST = 255;
 
-// Bits de parede armazenados em paredes[x][y]
 constexpr char P_NORTE = 0x1;
 constexpr char P_LESTE = 0x2;
 constexpr char P_SUL   = 0x4;
@@ -40,118 +20,35 @@ enum class Direcao : int { norte = 0, leste = 1, sul = 2, oeste = 3 };
 constexpr int NUM_DIRECOES = 4;
 constexpr int idx(Direcao d) { return static_cast<int>(d); }
 
-// Velocidade estimada em m/s baseada na constante VEL_BASE e no diâmetro da roda
-// VEL_BASE=160 (PWM) → ~70% da velocidade máxima; roda ø44mm → circunferência=138mm
-// Com 360 pulsos/volta e ~1000 pulsos/s em velocidade base ≈ 0,38 m/s
-static constexpr float VEL_ESTIMADA_MS = (VEL_BASE / 255.0f) * 
-                                          ((360.0f / PULSOSPORVOLTA) * 
-                                           (3.14159f * (DIAMETRO_RODA_MM / 1000.0f)));
-
-// ─── Classe Micromouse ─────────────────────────────────────────────────────
-
 class Micromouse {
 public:
     Micromouse() { reset(); }
 
-    /**
-     * @brief Executa uma corrida completa: do ponto (0,0) até o centro do labirinto.
-     *
-     * Sequência:
-     *  1. Lê dimensão pelas chaves DIP e envia RunStarted.
-     *  2. Loop: detecta paredes → envia CellDiscovered → Flood Fill → move.
-     *  3. Ao chegar no centro, envia RunFinished e para os motores.
-     */
     void run() {
-        // --- 1. Determinar dimensão pelo DIP switch ---
-        int dimensao = 16;
-        if (mapa_4x4()) dimensao = 4;
-        else if (mapa_8x8()) dimensao = 8;
-
-        // --- 2. Evento: Corrida Iniciada ---
-        int bat_inicial = battery_porcentagem();
-        Telemetry::sendRunStarted(dimensao, tentativa_atual, bat_inicial);
-        tentativa_atual++;
-
-        Serial.printf("[TEL] run_started | dim=%d bat=%d%%\n", dimensao, bat_inicial);
-
-        // Mapeia paredes de borda e calcula distâncias iniciais
         detectar_paredes();
         calcular_distancias();
-        ultima_checada = millis();
 
-        // --- 3. Loop de navegação ---
         while (!centro(pos_x, pos_y)) {
-            // Mantém o WebSocket ativo em segundo plano
-            Telemetry::process();
-
-            // Detecta paredes na célula atual usando os sensores IR
             detectar_paredes();
-
-            // Lê o estado atual das paredes desta célula do mapa interno
-            bool p_norte = tem_parede(pos_x, pos_y, Direcao::norte);
-            bool p_sul   = tem_parede(pos_x, pos_y, Direcao::sul);
-            bool p_leste = tem_parede(pos_x, pos_y, Direcao::leste);
-            bool p_oeste = tem_parede(pos_x, pos_y, Direcao::oeste);
-
-            // Converte enum Direcao para string ("N", "L", "S", "O")
-            const char* dir_str = direcao_para_str(direcao);
-
-            // Lê bateria real via ADC (divisor de tensão na hal.h)
-            float bat_atual = (float)battery_porcentagem();
-
-            // --- 4. Evento: Célula Descoberta ---
-            Telemetry::sendCellDiscovered(
-                pos_x, pos_y,
-                p_norte, p_sul, p_leste, p_oeste,
-                dir_str,
-                VEL_ESTIMADA_MS,
-                bat_atual
-            );
-
-            Serial.printf("[TEL] cell_discovered | (%d,%d) dir=%s bat=%.0f%%\n",
-                          pos_x, pos_y, dir_str, bat_atual);
-
-            // Loga bateria periodicamente no Serial (a cada 30s)
-            if (millis() - ultima_checada >= INTERVALO_BATERIA) {
-                Serial.printf("[BAT] Nível: %d%%\n", battery_porcentagem());
-                ultima_checada = millis();
-            }
-
             calcular_distancias();
-            melhor_celula();   // Move o robô fisicamente para a próxima célula
-
-            ota_loop();        // Mantém o servidor OTA respondendo durante a corrida
+            melhor_celula();
+            ota_loop();
         }
-
-        // --- 5. Evento: Corrida Finalizada ---
-        float bat_final = (float)battery_porcentagem();
-        Telemetry::sendRunFinished(true, VEL_ESTIMADA_MS, bat_final);
-        // Garante envio do último evento antes de parar
-        Telemetry::process();
-
-        Serial.printf("[TEL] run_finished | bat=%.0f%%\n", bat_final);
 
         motors_parar();
     }
 
 private:
-    unsigned long ultima_checada = 0;
-    const unsigned long INTERVALO_BATERIA = 30000;  // 30 segundos
-    int   distancia[TAM][TAM];
-    char  paredes[TAM][TAM];
-    int   pos_x = 0, pos_y = 0;
+    int     distancia[TAM][TAM];
+    char    paredes[TAM][TAM];
+    int     pos_x = 0, pos_y = 0;
     Direcao direcao = Direcao::norte;
-    int tentativa_atual = 1;
 
-    // Vetores de deslocamento por direção: norte→+y, leste→+x, sul→-y, oeste→-x
     static constexpr std::array<int, NUM_DIRECOES> move_x = { 0,  1,  0, -1 };
     static constexpr std::array<int, NUM_DIRECOES> move_y = { 1,  0, -1,  0 };
-
     static constexpr std::array<Direcao, NUM_DIRECOES> oposto = {
         Direcao::sul, Direcao::oeste, Direcao::norte, Direcao::leste
     };
-
-    // ── Helpers ──────────────────────────────────────────────────────────
 
     void reset() {
         pos_x   = 0;
@@ -177,19 +74,6 @@ private:
     bool tem_parede(int x, int y, Direcao d) const {
         return (paredes[x][y] & (1 << idx(d))) != 0;
     }
-
-    // Converte o enum Direcao para o código de string esperado pela telemetria
-    static const char* direcao_para_str(Direcao d) {
-        switch (d) {
-            case Direcao::norte: return "N";
-            case Direcao::leste: return "L";
-            case Direcao::sul:   return "S";
-            case Direcao::oeste: return "O";
-            default:             return "N";
-        }
-    }
-
-    // ── Flood Fill ────────────────────────────────────────────────────────
 
     void calcular_distancias() {
         for (int x = 0; x < TAM; x++)
@@ -222,8 +106,6 @@ private:
         }
     }
 
-    // ── Detecção de paredes (sensores IR reais) ───────────────────────────
-
     void adicionar_parede(int x, int y, Direcao d) {
         paredes[x][y] |= (1 << idx(d));
         int nx = x + move_x[idx(d)];
@@ -236,14 +118,6 @@ private:
         return static_cast<Direcao>((idx(dir_mouse) + giro) % NUM_DIRECOES);
     }
 
-    /**
-     * @brief Lê os três sensores IR (frente, direita, esquerda) e registra
-     *        as paredes detectadas no mapa interno do labirinto.
-     *
-     * sensor_parede_frente()    → sensor_cm(IR_FRENTE)   < DIST_FRONTAL_LIMITE_CM
-     * sensor_parede_direita()   → sensor_cm(IR_DIREITA)  < DIST_SEM_PAREDE_CM
-     * sensor_parede_esquerda()  → sensor_cm(IR_ESQUERDA) < DIST_SEM_PAREDE_CM
-     */
     void detectar_paredes() {
         if (sensor_parede_frente())
             adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 0));
@@ -253,15 +127,12 @@ private:
             adicionar_parede(pos_x, pos_y, relativa_para_absoluta(direcao, 3));
     }
 
-    // ── Movimento (motores reais com PID e encoders) ──────────────────────
-
     bool melhor_celula() {
         int melhor_direcao  = -1;
         int menor_distancia = MAX_DIST + 1;
 
         for (int d = 0; d < NUM_DIRECOES; d++) {
-            auto dir = static_cast<Direcao>(d);
-            if (tem_parede(pos_x, pos_y, dir)) continue;
+            if (tem_parede(pos_x, pos_y, static_cast<Direcao>(d))) continue;
             int nx = pos_x + move_x[d];
             int ny = pos_y + move_y[d];
             if (distancia[nx][ny] < menor_distancia) {
@@ -272,7 +143,6 @@ private:
 
         if (melhor_direcao == -1) return false;
 
-        // Gira o robô para apontar à direção desejada usando motors_girar_*()
         while (idx(direcao) != melhor_direcao) {
             int diferenca = (melhor_direcao - idx(direcao) + NUM_DIRECOES) % NUM_DIRECOES;
             if (diferenca == 1) {
@@ -284,15 +154,12 @@ private:
             }
         }
 
-        // Avança uma célula completa (controlado por encoders + PID)
         motors_avancar_celula();
         pos_x += move_x[melhor_direcao];
         pos_y += move_y[melhor_direcao];
         return true;
     }
 };
-
-// ─── Ponto de entrada da corrida (chamado pelo main.cpp) ──────────────────
 
 void micromouse_run() {
     Micromouse mouse;


### PR DESCRIPTION
## 📡 O que esta PR entrega

Esta branch implementa o **sistema de telemetria completo** do Micromouse, conectando o firmware da ESP32 ao backend Django em tempo real via WebSocket.

---

## ✅ O que está funcionando e implementado

### Firmware (ESP32)

| Arquivo | O que foi implementado |
|---------|----------------------|
| `Telemetry.h` / `Telemetry.cpp` | Cliente WebSocket com buffer FIFO de 50 eventos e retransmissão automática via ACK |
| `TelemetryTypes.h` | Structs tipados para os 3 eventos de telemetria |
| `mouse.cpp` | Algoritmo Flood Fill integrado com os 3 eventos de telemetria usando dados reais do hardware |
| `main.cpp` | Ponto de entrada com `Telemetry::init()` e `Telemetry::process()` no loop |
| `hal.h` | Mapeamento completo dos pinos da ESP32 (motores, encoders, sensores IR, bateria, DIP) |
| `motors`, `sensors`, `battery`, `dip`, `ota` | Drivers de hardware integrados |

**Eventos disparados com dados reais:**

| Evento | Quando | Dados reais usados |
|--------|--------|--------------------|
| `run_started` | Ao pressionar chave START | DIP switch (dimensão), ADC bateria |
| `cell_discovered` | A cada célula visitada | Sensores IR TCRT5000 (paredes), ADC bateria |
| `run_finished` | Ao atingir o centro | ADC bateria, velocidade estimada |

**Mecanismo de resiliência:**
- Buffer FIFO em RAM (50 eventos)
- Eventos ficam no buffer até receber ACK do backend
- Reconexão automática a cada 5 segundos se Wi-Fi cair
- `id_corrida` atualizado dinamicamente via ACK do `run_started`

### Backend (Django + Channels + Daphne)

- `FirmwareConsumer` em `ws/firmware/` recebe, persiste no banco e faz broadcast
- `CorridaConsumer` em `ws/corrida/live/` retransmite eventos ao frontend em tempo real
- `ALLOWED_HOSTS` atualizado para aceitar conexões da rede `rataturing` (192.168.4.1/2)

### Documentação

- `docs/pages/software/tutorial-telemetria.md`: tutorial completo passo a passo para **Arduino IDE** e **PlatformIO**, cobrindo configuração do firmware, backend, rede Wi-Fi, simulador Python e troubleshooting

---

## 🔧 Correções aplicadas nesta PR

| Correção | Arquivo | Detalhe |
|----------|---------|---------|
| `id_corrida` dinâmico | `Telemetry.cpp` | Antes estava hardcoded como `1`; agora é atualizado via ACK do `run_started` |
| Campos `linha`/`coluna` | `Telemetry.cpp` | Adicionados no payload de `cell_discovered` conforme contrato do `telemetria.md §6.2` |
| `ALLOWED_HOSTS` | `settings.py` | Adicionados IPs `192.168.4.1` e `192.168.4.2` da rede AP da ESP32 |

---

## ⚠️ Bug identificado no Frontend (fora do escopo desta PR)

> **Não foi alterado nenhum arquivo de frontend nesta branch.**

No `Dashboard.jsx` (branch `frontend`), o botão **"Mover ratinho →"** referencia as variáveis `chaves` e `celulasMock` que **nunca foram declaradas** no componente. Ao ser clicado, o app lança um `ReferenceError` no console e pode travar.

**Localização:** `src/frontend/micromouse-dashborard/src/pages/Dashboard.jsx` linhas 111–121

**Impacto:** O fluxo real via WebSocket já funciona corretamente; o botão é um resquício de dados mock de uma fase anterior do desenvolvimento e deve ser removido.

**Correção:** remover o bloco do botão — a atualização do labirinto já acontece automaticamente via `ws.onmessage`.

---

## 🚀 Como testar esta PR

1. Configure o IP do backend em `src/firmware/Telemetry.cpp` linha 25
2. Faça o upload para a ESP32 via Arduino IDE ou PlatformIO
3. Inicie o backend: `python manage.py runserver 0.0.0.0:8000`
4. Conecte o PC na rede Wi-Fi `rataturing` (senha: `87654321`)
5. Ative a chave START e monitore via Serial (115200 baud)

Ou valide sem o robô físico:
```bash
cd src/backend
python telemetria/tests/simulador_ws.py
```

---

## 📁 Arquivos alterados

- `A` 19 arquivos novos em `src/firmware/`
- `M` `src/backend/config/settings.py` (ALLOWED_HOSTS)
- `A` `docs/pages/software/tutorial-telemetria.md`